### PR TITLE
detect kernel support for BPF_PROG_TEST_RUN and work around unsafe API

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -1,12 +1,26 @@
 package ebpf
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
+)
+
+// Errors returned by the implementation
+var (
+	ErrNotSupported = errors.New("ebpf: not supported by kernel")
+)
+
+const (
+	// Number of bytes to pad the output buffer for BPF_PROG_TEST_RUN.
+	// This is currently the maximum of spare space allocated for SKB
+	// and XDP programs, and equal to XDP_PACKET_HEADROOM + NET_IP_ALIGN.
+	outputPad = 256 + 2
 )
 
 // ProgramSpec is an interface that can initialize a new Program
@@ -71,6 +85,11 @@ func (bpf Program) Pin(fileName string) error {
 	return pinObject(fileName, uint32(bpf))
 }
 
+// Close unloads the program from the kernel.
+func (bpf Program) Close() error {
+	return syscall.Close(int(bpf))
+}
+
 // Test runs the Program in the kernel with the given input and returns the
 // value returned by the eBPF program. outLen may be zero.
 //
@@ -78,8 +97,8 @@ func (bpf Program) Pin(fileName string) error {
 // XDP and SKB programs.
 //
 // This function requires at least Linux 4.12.
-func (bpf Program) Test(in []byte, outLen int) (uint32, []byte, error) {
-	ret, out, _, err := bpf.testRun(in, outLen, 1)
+func (bpf Program) Test(in []byte) (uint32, []byte, error) {
+	ret, out, _, err := bpf.testRun(in, 1)
 	return ret, out, err
 }
 
@@ -88,11 +107,14 @@ func (bpf Program) Test(in []byte, outLen int) (uint32, []byte, error) {
 //
 // This function requires at least Linux 4.12.
 func (bpf Program) Benchmark(in []byte, repeat int) (time.Duration, error) {
-	_, _, total, err := bpf.testRun(in, 0, repeat)
+	_, _, total, err := bpf.testRun(in, repeat)
 	return total, err
 }
 
-func (bpf Program) testRun(in []byte, outLen int, repeat int) (uint32, []byte, time.Duration, error) {
+var noProgTestRun bool
+var detectProgTestRun sync.Once
+
+func (bpf Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duration, error) {
 	if repeat > math.MaxUint32 {
 		return 0, nil, 0, fmt.Errorf("repeat is too high")
 	}
@@ -105,39 +127,59 @@ func (bpf Program) testRun(in []byte, outLen int, repeat int) (uint32, []byte, t
 		return 0, nil, 0, fmt.Errorf("input is too long")
 	}
 
-	if outLen > math.MaxUint32 {
-		return 0, nil, 0, fmt.Errorf("output is too long")
+	detectProgTestRun.Do(func() {
+		prog, err := NewProgram(XDP, &Instructions{
+			BPFILdImm64(Reg0, 0),
+			BPFIOp(Exit),
+		}, "MIT", 0)
+		if err != nil {
+			// This may be because we lack sufficient permissions, etc.
+			return
+		}
+		defer prog.Close()
+
+		// XDP progs require at least 14 bytes input
+		in := make([]byte, 14)
+		attr := progTestRunAttr{
+			fd:         uint32(prog),
+			dataSizeIn: uint32(len(in)),
+			dataIn:     newPtr(unsafe.Pointer(&in[0])),
+		}
+		_, errno := bpfCall(_ProgTestRun, unsafe.Pointer(&attr), int(unsafe.Sizeof(attr)))
+		noProgTestRun = errno != 0
+	})
+
+	if noProgTestRun {
+		return 0, nil, 0, ErrNotSupported
 	}
 
-	var out []byte
-	var outPtr syscallPtr
-	if outLen > 0 {
-		out = make([]byte, outLen)
-		outPtr = newPtr(unsafe.Pointer(&out[0]))
-	}
+	// There is currently no way to tell the kernel about the size of the output buffer.
+	// Combined with things like bpf_xdp_adjust_head() we don't really know what the final
+	// size will be. Hence we allocate an output buffer which we hope will always be large
+	// enough, and panic if the kernel wrote past the end of the allocation.
+	// See https://marc.info/?l=linux-netdev&m=152283265832434&w=2
+	out := make([]byte, len(in)+outputPad)
 
 	attr := progTestRunAttr{
-		fd:          uint32(bpf),
-		dataSizeIn:  uint32(len(in)),
-		dataSizeOut: uint32(len(out)),
-		dataIn:      newPtr(unsafe.Pointer(&in[0])),
-		dataOut:     outPtr,
-		repeat:      uint32(repeat),
+		fd:         uint32(bpf),
+		dataSizeIn: uint32(len(in)),
+		// NB: dataSizeOut is not read by the kernel
+		dataIn:  newPtr(unsafe.Pointer(&in[0])),
+		dataOut: newPtr(unsafe.Pointer(&out[0])),
+		repeat:  uint32(repeat),
 	}
 
 	_, errno := bpfCall(_ProgTestRun, unsafe.Pointer(&attr), int(unsafe.Sizeof(attr)))
 	if errno != 0 {
-		if errno == syscall.EINVAL {
-			// bpf() returns EINVAL if _ProgTestRun is not supported AND if
-			// input size is out of bounds.
-			return 0, nil, 0, fmt.Errorf("kernel too old or input too small: %v", errno)
-		}
 		return 0, nil, 0, bpfErrNo(errno)
 	}
 
-	if out != nil {
-		out = out[:attr.dataSizeOut]
+	if int(attr.dataSizeOut) > cap(out) {
+		// Houston, we have a problem. The program created more data than we allocated,
+		// and the kernel wrote past the end of our buffer.
+		panic("kernel wrote past end of output buffer")
 	}
+	out = out[:int(attr.dataSizeOut)]
 
 	total := time.Duration(attr.duration) * time.Nanosecond
 	return attr.retval, out, total, nil

--- a/prog_test.go
+++ b/prog_test.go
@@ -1,0 +1,53 @@
+package ebpf
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestProgramRun(t *testing.T) {
+	pat := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	buf := make([]byte, 14)
+
+	// r1  : ctx_start
+	// r1+4: ctx_end
+	ins := Instructions{
+		// r2 = *(r1+4)
+		BPFIDstOffSrc(LdXW, Reg2, Reg1, 4),
+		// r1 = *(r1+0)
+		BPFIDstOffSrc(LdXW, Reg1, Reg1, 0),
+		// r3 = r1
+		BPFIDstSrc(MovSrc, Reg3, Reg1),
+		// r3 += len(buf)
+		BPFIDstImm(AddImm, Reg3, int32(len(buf))),
+		// if r3 > r2 goto +len(pat)
+		BPFIDstOffSrc(JGTSrc, Reg3, Reg2, int16(len(pat))),
+	}
+	for i, b := range pat {
+		ins = append(ins, BPFIDstOffImm(StB, Reg1, int16(i), int32(b)))
+	}
+	ins = append(ins,
+		// return 42
+		BPFILdImm64(Reg0, 42),
+		BPFIOp(Exit),
+	)
+
+	prog, err := NewProgram(XDP, &ins, "MIT", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	ret, out, err := prog.Test(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret != 42 {
+		t.Error("Expected return value to be 42, got", ret)
+	}
+
+	if !bytes.Equal(out[:len(pat)], pat) {
+		t.Errorf("Expected %v, got %v", pat, out)
+	}
+}


### PR DESCRIPTION
Detect whether we have support for BPF_PROG_TEST_RUN, and return a dedicated error if not.
This allows users of the package to skip tests that would otherwise fail.

Unfortunately, we also have to break the API. It turns out that the kernel interface doesn't
work the way I originally thought. In fact, it's not entirely clear how to use it in a safe
manner.

See https://marc.info/?l=linux-netdev&m=152283265832434&w=2 for context.