### PR TITLE
do not enforce instruction limits in user space

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -46,15 +46,11 @@ func NewProgram(progType ProgType, instructions Instructions, license string, ke
 			cInstructions = append(cInstructions, ins2)
 		}
 	}
-	insCount := uint32(len(cInstructions))
-	if insCount > MaxBPFInstructions {
-		return -1, fmt.Errorf("max instructions, %d, exceeded", MaxBPFInstructions)
-	}
 	lic := []byte(license)
 	logs := make([]byte, LogBufSize)
 	fd, e := bpfCall(_ProgLoad, unsafe.Pointer(&progCreateAttr{
 		progType:     progType,
-		insCount:     insCount,
+		insCount:     uint32(len(cInstructions)),
 		instructions: newPtr(unsafe.Pointer(&cInstructions[0])),
 		license:      newPtr(unsafe.Pointer(&lic[0])),
 		logLevel:     1,

--- a/types.go
+++ b/types.go
@@ -112,9 +112,6 @@ const (
 
 // Limits and constants for the the eBPF runtime
 const (
-	// MaxBPFInstructions is the maximum number of BPF instructions
-	// allowed by the BPF JIT
-	MaxBPFInstructions = 4096
 	// StackSize is the total size of the stack allocated for BPF programs
 	StackSize = 512
 	// InstructionSize is the size of the BPF instructions


### PR DESCRIPTION
BPF_MAXINSNS should not be enforced in user space, since it's possible that the limit will change in a future
version of the kernel. The E2BIG errno will result in an appropriate error message anyways.