### PR TITLE
rename Map, Program, Collection constructors and simplify Collection API

### DIFF
--- a/cmd/ebpf-dump/main.go
+++ b/cmd/ebpf-dump/main.go
@@ -21,12 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	oF, err := os.Open(flag.Args()[0])
-	if err != nil {
-		panic(err)
-	}
-	defer oF.Close()
-	spec, err := ebpf.NewCollectionSpecFromELF(oF)
+	spec, err := ebpf.LoadCollectionSpec(flag.Arg(0))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/ebpf-test/main.go
+++ b/cmd/ebpf-test/main.go
@@ -22,15 +22,15 @@ func main() {
 		os.Exit(42)
 	}
 
-	path := flag.Args()[0]
-	coll, err := ebpf.NewCollectionFromFile(path)
+	path := flag.Arg(0)
+	coll, err := ebpf.LoadCollection(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't load %s: %v\n", path, err)
 		os.Exit(42)
 	}
 
-	progName := flag.Args()[1]
-	prog, ok := coll.GetProgramByName(progName)
+	progName := flag.Arg(1)
+	prog, ok := coll.Programs[progName]
 	if !ok {
 		fmt.Fprintf(os.Stderr, "%v does not contain program %v\n", path, progName)
 		os.Exit(42)

--- a/editor_test.go
+++ b/editor_test.go
@@ -33,7 +33,7 @@ func ExampleEditor_RewriteUint64() {
 }
 
 func TestEditorRewriteGlobalVariables(t *testing.T) {
-	spec, err := NewCollectionSpecFromFile("testdata/rewrite.elf")
+	spec, err := LoadCollectionSpec("testdata/rewrite.elf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestEditorRewriteGlobalVariables(t *testing.T) {
 }
 
 func TestEditorRejectInvalidRewrites(t *testing.T) {
-	spec, err := NewCollectionSpecFromFile("testdata/rewrite.elf")
+	spec, err := LoadCollectionSpec("testdata/rewrite.elf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/elf.go
+++ b/elf.go
@@ -15,9 +15,9 @@ type elfCode struct {
 	symtab *symtab
 }
 
-// NewCollectionSpecFromELF parses an io.ReaderAt that represents an ELF layout
+// LoadCollectionSpecFromReader parses an io.ReaderAt that represents an ELF layout
 // into a CollectionSpec.
-func NewCollectionSpecFromELF(code io.ReaderAt) (*CollectionSpec, error) {
+func LoadCollectionSpecFromReader(code io.ReaderAt) (*CollectionSpec, error) {
 	f, err := elf.NewFile(code)
 	if err != nil {
 		return nil, err

--- a/elf_test.go
+++ b/elf_test.go
@@ -8,14 +8,14 @@ import (
 	"testing"
 )
 
-func TestNewCollectionSpecFromELF(t *testing.T) {
+func TestLoadCollectionSpec(t *testing.T) {
 	fh, err := os.Open("testdata/loader.elf")
 	if err != nil {
 		t.Fatal("Can't open test ELF:", err)
 	}
 	defer fh.Close()
 
-	spec, err := NewCollectionSpecFromELF(fh)
+	spec, err := LoadCollectionSpecFromReader(fh)
 	if err != nil {
 		t.Fatal("Can't parse ELF:", err)
 	}

--- a/example_sock_elf_test.go
+++ b/example_sock_elf_test.go
@@ -94,12 +94,12 @@ func Example_socketELF() {
 	}
 	var coll *ebpf.Collection
 	if fi != nil {
-		coll, err = ebpf.LoadCollection(sockexPin)
+		coll, err = ebpf.LoadPinnedCollection(sockexPin)
 		if err != nil {
 			panic(err)
 		}
 	} else {
-		spec, err := ebpf.NewCollectionSpecFromELF(bytes.NewReader(program[:]))
+		spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(program[:]))
 		if err != nil {
 			panic(err)
 		}
@@ -116,7 +116,7 @@ func Example_socketELF() {
 	if err != nil {
 		panic(err)
 	}
-	prog, ok := coll.GetProgramByName("bpf_prog1")
+	prog, ok := coll.Programs["bpf_prog1"]
 	if !ok {
 		panic(fmt.Errorf("no program named \"bpf_prog1\" found"))
 	}
@@ -126,7 +126,7 @@ func Example_socketELF() {
 
 	fmt.Printf("Filtering on eth index: %d\n", *index)
 	fmt.Println("Packet stats:")
-	bpfMap, ok := coll.GetMapByName("my_map")
+	bpfMap, ok := coll.Maps["my_map"]
 	if !ok {
 		panic(fmt.Errorf("no map named \"my_map\" found"))
 	}

--- a/example_sock_file_test.go
+++ b/example_sock_file_test.go
@@ -20,7 +20,7 @@ func Example_socketELFFile() {
 	fileName := flag.String("file", "", "path to sockex1")
 	index := flag.Int("index", 0, "specify ethernet index")
 	flag.Parse()
-	coll, err := ebpf.NewCollectionFromFile(*fileName)
+	coll, err := ebpf.LoadCollection(*fileName)
 	if err != nil {
 		panic(err)
 	}
@@ -28,7 +28,7 @@ func Example_socketELFFile() {
 	if err != nil {
 		panic(err)
 	}
-	prog, ok := coll.GetProgramByName("bpf_prog1")
+	prog, ok := coll.Programs["bpf_prog1"]
 	if !ok {
 		panic(fmt.Errorf("no program named \"bpf_prog1\" found"))
 	}
@@ -37,7 +37,7 @@ func Example_socketELFFile() {
 	}
 	fmt.Printf("Filtering on eth index: %d\n", *index)
 	fmt.Println("Packet stats:")
-	bpfMap, ok := coll.GetMapByName("my_map")
+	bpfMap, ok := coll.Maps["my_map"]
 	if !ok {
 		panic(fmt.Errorf("no map named \"my_map\" found"))
 	}

--- a/map.go
+++ b/map.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// MapSpec is an interface type that can initialize a new Map
+// MapSpec defines a Map.
 type MapSpec struct {
 	Type       MapType
 	KeySize    uint32
@@ -270,11 +270,11 @@ func (m *Map) Pin(fileName string) error {
 	return pinObject(fileName, m.fd)
 }
 
-// LoadMap load a Map from a BPF file.
+// LoadPinnedMap load a Map from a BPF file.
 //
-// Requires at least Linux 4.13, use LoadMapExplicit on
+// Requires at least Linux 4.13, use LoadPinnedMapExplicit on
 // earlier versions.
-func LoadMap(fileName string) (*Map, error) {
+func LoadPinnedMap(fileName string) (*Map, error) {
 	fd, err := getObject(fileName)
 	if err != nil {
 		return nil, err
@@ -286,8 +286,8 @@ func LoadMap(fileName string) (*Map, error) {
 	return alignMap(fd, spec)
 }
 
-// LoadMapExplicit loads a map with explicit parameters.
-func LoadMapExplicit(fileName string, spec *MapSpec) (*Map, error) {
+// LoadPinnedMapExplicit loads a map with explicit parameters.
+func LoadPinnedMapExplicit(fileName string, spec *MapSpec) (*Map, error) {
 	fd, err := getObject(fileName)
 	if err != nil {
 		return nil, err

--- a/map_test.go
+++ b/map_test.go
@@ -78,7 +78,7 @@ func TestMapPin(t *testing.T) {
 	}
 	m.Close()
 
-	m, err = LoadMap(path)
+	m, err = LoadPinnedMap(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/prog.go
+++ b/prog.go
@@ -194,11 +194,11 @@ func (bpf *Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duratio
 	return attr.retval, out, total, nil
 }
 
-// LoadProgram loads a Program from a BPF file.
+// LoadPinnedProgram loads a Program from a BPF file.
 //
-// Requires at least Linux 4.13, use LoadProgramExplicit on
+// Requires at least Linux 4.13, use LoadPinnedProgramExplicit on
 // earlier versions.
-func LoadProgram(fileName string) (*Program, error) {
+func LoadPinnedProgram(fileName string) (*Program, error) {
 	fd, err := getObject(fileName)
 	if err != nil {
 		return nil, err
@@ -214,8 +214,8 @@ func LoadProgram(fileName string) (*Program, error) {
 	}, nil
 }
 
-// LoadProgramExplicit loads a program with explicit parameters.
-func LoadProgramExplicit(fileName string, typ ProgType) (*Program, error) {
+// LoadPinnedProgramExplicit loads a program with explicit parameters.
+func LoadPinnedProgramExplicit(fileName string, typ ProgType) (*Program, error) {
 	fd, err := getObject(fileName)
 	if err != nil {
 		return nil, err

--- a/prog_test.go
+++ b/prog_test.go
@@ -81,7 +81,7 @@ func TestProgramPin(t *testing.T) {
 	}
 	prog.Close()
 
-	prog, err = LoadProgram(path)
+	prog, err = LoadPinnedProgram(path)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

Even as a contributor to the package I find it hard to predict which function I should use to read a map, etc. The current API for collections is also cumbersome, I'd rather access Maps and Programs directly.

This is a large change API wise, so I'd like to get your thoughts on this.
