### PR TITLE
stub out Linux specific syscalls on other platforms

### DIFF
--- a/syscalls_linux.go
+++ b/syscalls_linux.go
@@ -1,0 +1,10 @@
+package ebpf
+
+import (
+	"syscall"
+)
+
+const (
+	_SYS_PERF_EVENT_OPEN = syscall.SYS_PERF_EVENT_OPEN
+	_EBADFD              = syscall.EBADFD
+)

--- a/syscalls_stub.go
+++ b/syscalls_stub.go
@@ -1,0 +1,14 @@
+//+build !linux
+
+package ebpf
+
+import (
+	"syscall"
+)
+
+// These syscall numbers are not available on non-Linux platforms.
+// Stub them out to allow code completion to work at least.
+const (
+	_SYS_PERF_EVENT_OPEN = 0xdeadbeef
+	_EBADFD              = syscall.Errno(0xdeadbeef)
+)


### PR DESCRIPTION
**What this PR does / why we need it:**

This allows things like linters, etc. work on other platforms as well.