### PR TITLE
fix too small verifier buffer breaking loads

### DIFF
--- a/prog_test.go
+++ b/prog_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -89,5 +90,22 @@ func TestProgramPin(t *testing.T) {
 
 	if prog.progType != XDP {
 		t.Error("Expected pinned program to have type XDP, but got", prog.progType)
+	}
+}
+
+func TestProgramVerifierOutput(t *testing.T) {
+	_, err := NewProgram(&ProgramSpec{
+		Type: XDP,
+		Instructions: Instructions{
+			BPFIOp(Exit),
+		},
+		License: "MIT",
+	})
+	if err == nil {
+		t.Fatal("Expected program to be invalid")
+	}
+
+	if strings.Index(err.Error(), "exit") == -1 {
+		t.Error("No verifier output in error message")
 	}
 }

--- a/types.go
+++ b/types.go
@@ -105,8 +105,6 @@ const (
 	StackSize = 512
 	// InstructionSize is the size of the BPF instructions
 	InstructionSize = 8
-	// LogBufSize is the size of the log buffer for debugging issues
-	LogBufSize = 65536
 )
 
 // Class masks for eBPF operators


### PR DESCRIPTION
The BPF syscall returns an error if the allocated logbuffer is too small to hold all output.
This means that we can't load large BPF programs. To work around this we load without
logging enabled by default, and re-run a load on error.

In the future we should provide an API which allows users to change the buffer size.