### PR TITLE
fix retrieving the number of possible CPUs on single core systems

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -176,6 +176,14 @@ func TestIterateEmptyMap(t *testing.T) {
 }
 
 func TestPerCPUMarshaling(t *testing.T) {
+	numCPU, err := possibleCPUs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if numCPU < 2 {
+		t.Skip("Test requires at least two CPUs")
+	}
+
 	arr, err := NewMap(&MapSpec{
 		Type:       PerCPUArray,
 		KeySize:    4,
@@ -255,10 +263,6 @@ func ExampleMap_PerCPU() {
 	if err := entries.Err(); err != nil {
 		panic(err)
 	}
-
-	// Output: First two values: [4 5]
-	// Sum of 0: 9
-	// Sum of 1: 10
 }
 
 func createHash() *Map {

--- a/marshalers.go
+++ b/marshalers.go
@@ -190,14 +190,13 @@ func possibleCPUs() (int, error) {
 		}
 
 		var low, high int
-		n, err := fmt.Fscanf(bytes.NewReader(buf), "%d-%d", &low, &high)
-		if err != nil {
-			sysCPU.err = err
-			return
-		}
-		if n != 2 || low != 0 {
+		n, _ := fmt.Fscanf(bytes.NewReader(buf), "%d-%d", &low, &high)
+		if n < 1 || low != 0 {
 			sysCPU.err = errors.New("/sys/devices/system/cpu/possible has unknown format")
 			return
+		}
+		if n == 1 {
+			high = low
 		}
 
 		sysCPU.num = high + 1


### PR DESCRIPTION
The current code returned a very cryptic error on single core systems, where possible CPUs returns just a single number.

Return a better error, and skip tests which require multiple CPUs to be present on single core systems.
