### PR TITLE
don't specialise ENOSPC to BPF_PROG_LOAD

### DIFF
--- a/syscalls.go
+++ b/syscalls.go
@@ -212,8 +212,6 @@ func bpfCall(cmd int, attr unsafe.Pointer, size uintptr) (uintptr, error) {
 		err = &wrappedErrno{syscall.EBADF, "not an open file descriptor"}
 	case syscall.EACCES:
 		err = &wrappedErrno{syscall.EACCES, "bpf program rejected as unsafe"}
-	case syscall.ENOSPC:
-		err = &wrappedErrno{syscall.ENOSPC, "bpf logging buffer not large enough"}
 	default:
 		err = errNo
 	}


### PR DESCRIPTION
ENOSPC is also returned by map calls which exceed available space, and the error message is
confusing in that case.
