### PR TITLE
Set finalizers on Map and Program

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -142,17 +142,32 @@ func TestMapInMap(t *testing.T) {
 				t.Fatal("Can't put inner map:", err)
 			}
 
-			if ok, err := outer.Get(uint32(0), inner); err != nil {
+			var inner2 Map
+			if ok, err := outer.Get(uint32(0), &inner2); err != nil {
 				t.Fatal(err)
 			} else if !ok {
 				t.Fatal("Missing key 0")
 			}
+			defer inner2.Close()
 
 			var v uint32
-			if ok, err := inner.Get(uint32(1), &v); err != nil {
+			if ok, err := inner2.Get(uint32(1), &v); err != nil {
 				t.Fatal(err, inner)
 			} else if !ok {
 				t.Fatal("Missing key 0")
+			}
+
+			if v != 4242 {
+				t.Error("Expected value 4242, got", v)
+			}
+
+			inner2.Close()
+
+			// Make sure we can still access the original map
+			if ok, err := inner.Get(uint32(1), &v); err != nil {
+				t.Fatal(err, inner)
+			} else if !ok {
+				t.Fatal("Missing key 0 from inner")
 			}
 
 			if v != 4242 {

--- a/prog.go
+++ b/prog.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"fmt"
 	"math"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -66,6 +67,7 @@ func NewProgram(spec *ProgramSpec) (*Program, error) {
 			uint32(fd),
 			spec.Type,
 		}
+		runtime.SetFinalizer(prog, (*Program).Close)
 		return prog, nil
 	}
 
@@ -100,6 +102,7 @@ func (bpf *Program) Pin(fileName string) error {
 
 // Close unloads the program from the kernel.
 func (bpf *Program) Close() error {
+	runtime.SetFinalizer(bpf, nil)
 	return syscall.Close(int(bpf.fd))
 }
 


### PR DESCRIPTION
Leaking a Map or Program currently also leaks the kernel space resource. For a long running process
this can be lethal. Use the runtime.SetFinalizer machinery to handle things a little bit more
gracefully. This also means that it's not safe to unmarshal into an existing Map anymore, but
that was probably a bad idea from the start.