### PR TITLE
Editor: Replace movsrc with movimm

### DIFF
--- a/editor_test.go
+++ b/editor_test.go
@@ -27,8 +27,8 @@ func ExampleEditor_RewriteUint64() {
 
 	fmt.Printf("%0.0s", insns)
 
-	// Output: 0: LdImmDW dst: r0 imm: 42
-	// 2: MovSrc dst: r0 src: r0
+	// Output: 0: LdImmDW dst: r0 imm: 0
+	// 2: MovImm dst: r0 imm: 42
 	// 3: Exit
 }
 


### PR DESCRIPTION
The BPF verifier resets the bounds of registers in the case of
`MOV rN = rN`, which causes other instructions to be rejected as out of
bounds / invald. After rewriting globals, we sometimes end up with such
instructions.

Instead of changing the initial LOAD to load the constant value, leave
the LOAD alone and replace the MOVSRC with a MOVIMM that loads the
constant value. MOVIMM doesn't trigger the verifier bug.