### PR TITLE
add DetachMap and DetachProgram helpers

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -96,6 +96,28 @@ func (coll *Collection) Close() {
 	}
 }
 
+// DetachMap removes the named map from the Collection.
+//
+// This means that a later call to Close() will not affect this map.
+//
+// Returns nil if no map of that name exists.
+func (coll *Collection) DetachMap(name string) *Map {
+	m := coll.Maps[name]
+	delete(coll.Maps, name)
+	return m
+}
+
+// DetachProgram removes the named program from the Collection.
+//
+// This means that a later call to Close() will not affect this program.
+//
+// Returns nil if no program of that name exists.
+func (coll *Collection) DetachProgram(name string) *Program {
+	p := coll.Programs[name]
+	delete(coll.Programs, name)
+	return p
+}
+
 // Pin persits a Collection beyond the lifetime of the process that created it
 //
 // This requires bpffs to be mounted above fileName. See http://cilium.readthedocs.io/en/doc-1.0/kubernetes/install/#mounting-the-bpf-fs-optional

--- a/elf_test.go
+++ b/elf_test.go
@@ -55,6 +55,26 @@ func TestLoadCollectionSpec(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer coll.Close()
+
+	hash := coll.DetachMap("hash_map")
+	if hash == nil {
+		t.Fatal("Program not returned from DetachMap")
+	}
+	defer hash.Close()
+
+	if _, ok := coll.Programs["hash_map"]; ok {
+		t.Error("DetachMap doesn't remove map from Maps")
+	}
+
+	prog := coll.DetachProgram("xdp_prog")
+	if prog == nil {
+		t.Fatal("Program not returned from DetachProgram")
+	}
+	defer prog.Close()
+
+	if _, ok := coll.Programs["xdp_prog"]; ok {
+		t.Error("DetachProgram doesn't remove program from Programs")
+	}
 }
 
 func Test64bitImmediate(t *testing.T) {


### PR DESCRIPTION
It's currently complicated to write code which reliably cleans up references
to maps or programs on errors.

    coll, err := LoadCollection("/some/file")

    // ...

    if err != nil {
        // We leak coll at this point
	return err
    }

DetachMap and DetachProgram make this a bit nicer:

    coll, err := LoadCollection("/some/file")
    // Handle err
    defer coll.Close()

    myMap := coll.DetachMap("my_map")
    defer myMap.Close()

    // ...

    if err != nil {
	return err
    }

    return coll.DetachProgram("my_program")

This has the nice side benefit that anything in coll which is not
explicitly used by the user space program is freed as soon as the enclosing
function returns.
