### PR TITLE
Rename RewriteAddress to RewriteConstant

### DIFF
--- a/editor_test.go
+++ b/editor_test.go
@@ -25,7 +25,7 @@ func ExampleEditor_rewriteConstant() {
 	}
 
 	editor := Edit(&insns)
-	if err := editor.RewriteAddress("my_ret", 42); err != nil {
+	if err := editor.RewriteConstant("my_ret", 42); err != nil {
 		panic(err)
 	}
 
@@ -44,8 +44,7 @@ func TestEditorRewriteConstant(t *testing.T) {
 	progSpec := spec.Programs["rewrite"]
 	editor := Edit(&progSpec.Instructions)
 
-	// Rewrite scalars
-	if err := editor.RewriteAddress("constant", 0x01); err != nil {
+	if err := editor.RewriteConstant("constant", 0x01); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,7 +80,7 @@ func TestEditorIssue59(t *testing.T) {
 	}
 
 	editor := Edit(&insns)
-	if err := editor.RewriteAddress("my_ret", int64(max)); err != nil {
+	if err := editor.RewriteConstant("my_ret", max); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
I made a mistake when naming the function initially. Seeing RewriteAddress in client
code is very confusing and makes it harder to follow.

Rename it to RewriteConstant and make it take an uint64 (basically untyped 64 bit constant)
and explain how this whole contraption works. Brave souls can then still decide for / against
using this.
