### PR TITLE
Remove SamplePeriod option from PerfReader

### DIFF
--- a/perf.go
+++ b/perf.go
@@ -59,7 +59,6 @@ func newPerfEventRing(cpu int, opts PerfReaderOptions) (*perfEventRing, error) {
 		perfType:                perfTypeSoftware,
 		config:                  perfCountSWBPFOutput,
 		flags:                   flagWakeupWatermark,
-		samplePeriod:            opts.SamplePeriod,
 		sampleType:              perfSampleRaw,
 		wakeupEventsOrWatermark: uint32(opts.Watermark),
 	}
@@ -208,9 +207,6 @@ type PerfReaderOptions struct {
 	// A map of type PerfEventArray. The reader takes ownership of the
 	// map and takes care of closing it.
 	Map *Map
-	// Controls how many calls to bpf_perf_event_output are sampled.
-	// A value of 1 includes every call.
-	SamplePeriod uint64
 	// Controls the size of the per CPU buffer in bytes. LostSamples() will
 	// increase if the buffer is too small.
 	PerCPUBuffer int

--- a/perf_test.go
+++ b/perf_test.go
@@ -17,7 +17,6 @@ func TestPerfReader(t *testing.T) {
 
 	rd, err := NewPerfReader(PerfReaderOptions{
 		Map:          coll.DetachMap("events"),
-		SamplePeriod: 1,
 		PerCPUBuffer: 4096,
 		Watermark:    1,
 	})
@@ -55,7 +54,6 @@ func TestPerfReaderLostSample(t *testing.T) {
 
 	rd, err := NewPerfReader(PerfReaderOptions{
 		Map:          coll.DetachMap("events"),
-		SamplePeriod: 1,
 		PerCPUBuffer: 4096,
 		// This is chosen to notify _after_ the lost sample record
 		// has been created.
@@ -173,9 +171,7 @@ func ExamplePerfReader() {
 	defer coll.Close()
 
 	rd, err := NewPerfReader(PerfReaderOptions{
-		Map: coll.DetachMap("events"),
-		// Sample each call to bpf_perf_event_output
-		SamplePeriod: 1,
+		Map:          coll.DetachMap("events"),
 		PerCPUBuffer: 4096,
 		// Notify immediately
 		Watermark: 1,


### PR DESCRIPTION
It turns out that perf_event_output ignores the sample_period set on
invidivual event fds, and writes all samples to the ring buffers.
