### PR TITLE
Fixes to the Perf Reader

### DIFF
--- a/perf_test.go
+++ b/perf_test.go
@@ -125,7 +125,7 @@ func TestRingBuffer(t *testing.T) {
 	}
 }
 
-func makeRing(size, offset int) *ringBuffer {
+func makeRing(size, offset int) *ringReader {
 	if size%2 != 0 {
 		panic("size must be power of two")
 	}
@@ -141,7 +141,7 @@ func makeRing(size, offset int) *ringBuffer {
 		dataSize: uint64(len(ring)),
 	}
 
-	return newRingBuffer(&meta, ring)
+	return newRingReader(&meta, ring)
 }
 
 // ExamplePerfReader submits a perf event using BPF,


### PR DESCRIPTION
This PR moves some code around to make it easier to follow the logic, and cleans up an fd leak. A nice side effect is that we now take less locks in the perf reader (due to not checking for pr.close).