### PR TITLE
Use golang.org/x/sys/unix for epoll

### DIFF
--- a/perf.go
+++ b/perf.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -315,10 +316,10 @@ func (pr *PerfReader) poll(epollFd int, rings map[int]*perfEventRing, samples ch
 		}
 	}()
 
-	epollEvents := make([]syscall.EpollEvent, len(rings)+1)
+	epollEvents := make([]unix.EpollEvent, len(rings)+1)
 
 	for {
-		nEvents, err := syscall.EpollWait(epollFd, epollEvents, -1)
+		nEvents, err := unix.EpollWait(epollFd, epollEvents, -1)
 		if err != nil {
 			// Handle EINTR
 			if temp, ok := err.(temporaryError); ok && temp.Temporary() {

--- a/syscalls.go
+++ b/syscalls.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 type mapCreateAttr struct {
@@ -283,18 +284,18 @@ func newEventFd() (int, error) {
 }
 
 func newEpollFd(fds ...int) (int, error) {
-	epollfd, err := syscall.EpollCreate1(syscall.EPOLL_CLOEXEC)
+	epollfd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if err != nil {
 		return -1, errors.Wrap(err, "can't create epoll fd")
 	}
 
 	for _, fd := range fds {
-		event := syscall.EpollEvent{
-			Events: syscall.EPOLLIN,
+		event := unix.EpollEvent{
+			Events: unix.EPOLLIN,
 			Fd:     int32(fd),
 		}
 
-		err := syscall.EpollCtl(epollfd, syscall.EPOLL_CTL_ADD, fd, &event)
+		err := unix.EpollCtl(epollfd, unix.EPOLL_CTL_ADD, fd, &event)
 		if err != nil {
 			syscall.Close(epollfd)
 			return -1, errors.Wrap(err, "can't add fd to epoll")


### PR DESCRIPTION
It turns out that syscall.EpollEvent is incorrect on arm64 due to
missing padding. Work around this by using the newer x/sys/unix
package for epoll definitions.
