### PR TITLE
asm: fix marshalling signed jumps comparing with -1

### DIFF
--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"testing"
 )
@@ -43,6 +44,19 @@ func TestWrite64bitImmediate(t *testing.T) {
 
 	if prog := buf.Bytes(); !bytes.Equal(prog, test64bitImmProg) {
 		t.Errorf("Marshalled program does not match:\n%s", hex.Dump(prog))
+	}
+}
+
+func TestSignedJump(t *testing.T) {
+	insns := Instructions{
+		JSGT.Imm(R0, -1, "foo"),
+	}
+
+	insns[0].Offset = 1
+
+	err := insns.Marshal(ioutil.Discard, binary.LittleEndian)
+	if err != nil {
+		t.Error("Can't marshal signed jump:", err)
 	}
 }
 


### PR DESCRIPTION
It's perfectly valid to have an instruction like this:

    JSGTImm dst: r1 off: 4 imm: -1 ; if r1 > -1 goto PC+4

Since the offset is not -1 it does not need rewriting.
The current code is too lazy in checking for this condition,
and tries to rewrite both bpf to bpf calls and jumps in the
same block.

Separate these two cases, and add a comment so I can remember
what does what.

Please provide a clear and concise explanation of what this PR does/fixes and why ebpf needs it.

(Optional)
Fixes #
