### PR TITLE
add collection, map and program ABI

### DIFF
--- a/abi.go
+++ b/abi.go
@@ -1,0 +1,176 @@
+package ebpf
+
+import (
+	"github.com/pkg/errors"
+)
+
+// CollectionABI describes the interface of an eBPF collection.
+type CollectionABI struct {
+	Maps     map[string]*MapABI
+	Programs map[string]*ProgramABI
+}
+
+// CheckSpec verifies that all maps and programs mentioned
+// in the ABI are present in the spec.
+func (abi *CollectionABI) CheckSpec(cs *CollectionSpec) error {
+	for name := range abi.Maps {
+		if cs.Maps[name] == nil {
+			return errors.Errorf("missing map %s", name)
+		}
+	}
+
+	for name := range abi.Programs {
+		if cs.Programs[name] == nil {
+			return errors.Errorf("missing program %s", name)
+		}
+	}
+
+	return nil
+}
+
+// Check verifies that all items in a collection conform to this ABI.
+func (abi *CollectionABI) Check(coll *Collection) error {
+	for name, mapABI := range abi.Maps {
+		m := coll.Maps[name]
+		if m == nil {
+			return errors.Errorf("missing map %s", name)
+		}
+		if err := mapABI.Check(m); err != nil {
+			return errors.Wrapf(err, "map %s", name)
+		}
+	}
+
+	for name, progABI := range abi.Programs {
+		p := coll.Programs[name]
+		if p == nil {
+			return errors.Errorf("missing program %s", name)
+		}
+		if err := progABI.Check(p); err != nil {
+			return errors.Wrapf(err, "program %s", name)
+		}
+	}
+
+	return nil
+}
+
+// MapABI describes a Map.
+//
+// Members which have the zero value of their type
+// are not checked.
+type MapABI struct {
+	Type       MapType
+	KeySize    uint32
+	ValueSize  uint32
+	MaxEntries uint32
+	InnerMap   *MapABI
+}
+
+func newMapABIFromSpec(spec *MapSpec) *MapABI {
+	var inner *MapABI
+	if spec.InnerMap != nil {
+		inner = newMapABIFromSpec(spec.InnerMap)
+	}
+
+	return &MapABI{
+		spec.Type,
+		spec.KeySize,
+		spec.ValueSize,
+		spec.MaxEntries,
+		inner,
+	}
+}
+
+func newMapABIFromFd(fd uint32) (*MapABI, error) {
+	info, err := getMapInfoByFD(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	mapType := MapType(info.mapType)
+	if mapType == ArrayOfMaps || mapType == HashOfMaps {
+		return nil, errors.New("can't get map info for nested maps")
+	}
+
+	return &MapABI{
+		mapType,
+		info.keySize,
+		info.valueSize,
+		info.maxEntries,
+		nil,
+	}, nil
+}
+
+// Check verifies that a Map conforms to the ABI.
+func (abi *MapABI) Check(m *Map) error {
+	return abi.check(&m.abi)
+}
+
+func (abi *MapABI) check(other *MapABI) error {
+	if abi.Type != UnspecifiedMap && other.Type != abi.Type {
+		return errors.Errorf("expected map type %s, have %s", abi.Type, other.Type)
+	}
+	if err := checkUint32("key size", abi.KeySize, other.KeySize); err != nil {
+		return err
+	}
+	if err := checkUint32("value size", abi.ValueSize, other.ValueSize); err != nil {
+		return err
+	}
+	if err := checkUint32("max entries", abi.MaxEntries, other.MaxEntries); err != nil {
+		return err
+	}
+
+	if abi.InnerMap == nil {
+		if abi.Type == ArrayOfMaps || abi.Type == HashOfMaps {
+			return errors.New("missing inner map ABI")
+		}
+
+		return nil
+	}
+
+	if other.InnerMap == nil {
+		return errors.New("missing inner map")
+	}
+
+	return errors.Wrap(abi.InnerMap.check(other.InnerMap), "inner map")
+}
+
+// ProgramABI describes a Program.
+//
+// Members which have the zero value of their type
+// are not checked.
+type ProgramABI struct {
+	Type ProgType
+}
+
+func newProgramABIFromSpec(spec *ProgramSpec) *ProgramABI {
+	return &ProgramABI{
+		spec.Type,
+	}
+}
+
+func newProgramABIFromFd(fd uint32) (*ProgramABI, error) {
+	info, err := getProgInfoByFD(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProgramABI{
+		Type: ProgType(info.progType),
+	}, nil
+}
+
+// Check verifies that a Program conforms to the ABI.
+func (abi *ProgramABI) Check(prog *Program) error {
+	if abi.Type != Unrecognized && prog.abi.Type != abi.Type {
+		return errors.Errorf("expected program type %s, have %s", abi.Type, prog.abi.Type)
+	}
+
+	return nil
+}
+
+func checkUint32(name string, want, have uint32) error {
+	if want != 0 && have != want {
+		return errors.Errorf("expected %s to be %d, have %d", name, want, have)
+	}
+	return nil
+}

--- a/abi_test.go
+++ b/abi_test.go
@@ -1,0 +1,226 @@
+package ebpf
+
+import (
+	"testing"
+)
+
+func TestCollectionABI(t *testing.T) {
+	cabi := &CollectionABI{
+		Maps: map[string]*MapABI{
+			"a": {
+				Type:       ArrayOfMaps,
+				KeySize:    4,
+				ValueSize:  2,
+				MaxEntries: 3,
+				InnerMap: &MapABI{
+					Type: Array,
+				},
+			},
+		},
+		Programs: map[string]*ProgramABI{
+			"1": {Type: SocketFilter},
+		},
+	}
+
+	if err := cabi.CheckSpec(abiFixtureCollectionSpec()); err != nil {
+		t.Error("ABI check found error:", err)
+	}
+
+	cs := abiFixtureCollectionSpec()
+	delete(cs.Maps, "a")
+	if err := cabi.CheckSpec(cs); err == nil {
+		t.Error("Did not detect missing map")
+	}
+
+	cs = abiFixtureCollectionSpec()
+	delete(cs.Programs, "1")
+	if err := cabi.CheckSpec(cs); err == nil {
+		t.Error("Did not detect missing program")
+	}
+
+	if err := cabi.Check(abiFixtureCollection()); err != nil {
+		t.Error("ABI check found error:", err)
+
+	}
+
+	coll := abiFixtureCollection()
+	coll.Maps["a"].abi.KeySize = 12
+	if err := cabi.Check(coll); err == nil {
+		t.Error("Check not check map ABI")
+	}
+
+	delete(coll.Maps, "a")
+	if err := cabi.Check(coll); err == nil {
+		t.Error("Check did not detect missing map")
+	}
+
+	coll = abiFixtureCollection()
+	coll.Programs["1"].abi.Type = TracePoint
+	if err := cabi.Check(coll); err == nil {
+		t.Error("Did not check program ABI")
+	}
+
+	delete(coll.Programs, "1")
+	if err := cabi.Check(coll); err == nil {
+		t.Error("Check did not detect missing program")
+	}
+}
+
+func TestMapABI(t *testing.T) {
+	mabi := &MapABI{
+		Type:       ArrayOfMaps,
+		KeySize:    4,
+		ValueSize:  2,
+		MaxEntries: 3,
+		InnerMap: &MapABI{
+			Type: Array,
+		},
+	}
+
+	if err := mabi.Check(abiFixtureMap()); err != nil {
+		t.Error("ABI check found error:", err)
+	}
+
+	fm := abiFixtureMap()
+	fm.abi.Type = Hash
+	if err := mabi.Check(fm); err == nil {
+		t.Error("Did not detect incorrect type")
+	}
+
+	fm = abiFixtureMap()
+	fm.abi.KeySize = 3
+	if err := mabi.Check(fm); err == nil {
+		t.Error("Did not detect incorrect key size")
+	}
+
+	fm = abiFixtureMap()
+	fm.abi.ValueSize = 23
+	if err := mabi.Check(fm); err == nil {
+		t.Error("Did not detect incorrect value size")
+	}
+
+	fm = abiFixtureMap()
+	fm.abi.MaxEntries = 23
+	if err := mabi.Check(fm); err == nil {
+		t.Error("Did not detect incorrect max entries")
+	}
+
+	fm = abiFixtureMap()
+	mabi.InnerMap.Type = Hash
+	if err := mabi.Check(fm); err == nil {
+		t.Error("Did not detect incorrect inner map type")
+	}
+
+	fm = abiFixtureMap()
+	mabi.InnerMap = nil
+	if err := mabi.Check(fm); err == nil {
+		t.Error("Did not detect missing inner map ABI")
+	}
+}
+
+func TestProgramABI(t *testing.T) {
+	fabi := &ProgramABI{Type: SocketFilter}
+
+	if err := fabi.Check(abiFixtureProgram()); err != nil {
+		t.Error("ABI check found error:", err)
+	}
+
+	fp := abiFixtureProgram()
+	fp.abi.Type = TracePoint
+	if err := fabi.Check(fp); err == nil {
+		t.Error("Did not detect incorrect type")
+	}
+}
+
+func abiFixtureCollectionSpec() *CollectionSpec {
+	return &CollectionSpec{
+		Maps: map[string]*MapSpec{
+			"a": abiFixtureMapSpec(),
+		},
+		Programs: map[string]*ProgramSpec{
+			"1": abiFixtureProgramSpec(),
+		},
+	}
+}
+
+func abiFixtureCollection() *Collection {
+	return &Collection{
+		Maps: map[string]*Map{
+			"a": abiFixtureMap(),
+		},
+		Programs: map[string]*Program{
+			"1": abiFixtureProgram(),
+		},
+	}
+}
+
+func abiFixtureMapSpec() *MapSpec {
+	return &MapSpec{
+		Type:       ArrayOfMaps,
+		KeySize:    4,
+		ValueSize:  2,
+		MaxEntries: 3,
+		InnerMap: &MapSpec{
+			Type:    Array,
+			KeySize: 2,
+		},
+	}
+}
+
+func abiFixtureMap() *Map {
+	return &Map{
+		abi: *newMapABIFromSpec(abiFixtureMapSpec()),
+	}
+}
+
+func abiFixtureProgramSpec() *ProgramSpec {
+	return &ProgramSpec{
+		Type: SocketFilter,
+	}
+}
+
+func abiFixtureProgram() *Program {
+	return &Program{
+		abi: *newProgramABIFromSpec(abiFixtureProgramSpec()),
+	}
+}
+
+func ExampleCollectionABI() {
+	abi := CollectionABI{
+		Maps: map[string]*MapABI{
+			"a": {
+				Type: Array,
+				// Members which aren't specified are not checked
+			},
+			// Use an empty ABI if you just want to make sure
+			// something is present.
+			"b": {},
+		},
+		Programs: map[string]*ProgramABI{
+			"1": {Type: XDP},
+		},
+	}
+
+	spec, err := LoadCollectionSpec("from-somewhere.elf")
+	if err != nil {
+		panic(err)
+	}
+
+	// CheckSpec only makes sure that all entries of the ABI
+	// are present. It doesn't check whether the ABI is correct.
+	// See below for how to do that.
+	if err := abi.CheckSpec(spec); err != nil {
+		panic(err)
+	}
+
+	coll, err := NewCollection(spec)
+	if err != nil {
+		panic(err)
+	}
+
+	// Check finally compares the ABI and the collection, and
+	// makes sure that they match.
+	if err := abi.Check(coll); err != nil {
+		panic(err)
+	}
+}

--- a/elf_test.go
+++ b/elf_test.go
@@ -38,12 +38,14 @@ func TestLoadCollectionSpec(t *testing.T) {
 	})
 
 	checkProgramSpec(t, spec.Programs, "xdp_prog", &ProgramSpec{
-		Type:    XDP,
-		License: "MIT",
+		Type:          XDP,
+		License:       "MIT",
+		KernelVersion: 0,
 	})
 	checkProgramSpec(t, spec.Programs, "no_relocation", &ProgramSpec{
-		Type:    SocketFilter,
-		License: "MIT",
+		Type:          SocketFilter,
+		License:       "MIT",
+		KernelVersion: 0,
 	})
 
 	t.Log(spec.Programs["xdp_prog"].Instructions)

--- a/prog_test.go
+++ b/prog_test.go
@@ -92,8 +92,8 @@ func TestProgramPin(t *testing.T) {
 	}
 	defer prog.Close()
 
-	if prog.progType != SocketFilter {
-		t.Error("Expected pinned program to have type XDP, but got", prog.progType)
+	if prog.abi.Type != SocketFilter {
+		t.Error("Expected pinned program to have type SocketFilter, but got", prog.abi.Type)
 	}
 }
 

--- a/syscalls.go
+++ b/syscalls.go
@@ -169,26 +169,16 @@ func getObjectInfoByFD(fd uint32, info unsafe.Pointer, size uintptr) error {
 	return errors.Wrapf(err, "fd %d", fd)
 }
 
-func getMapSpecByFD(fd uint32) (*MapSpec, error) {
-	var info mapInfo
-	err := getObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info))
-	if err != nil {
-		return nil, errors.Wrap(err, "can't get info for map")
-	}
-	return &MapSpec{
-		MapType(info.mapType),
-		info.keySize,
-		info.valueSize,
-		info.maxEntries,
-		info.flags,
-		nil,
-	}, nil
-}
-
 func getProgInfoByFD(fd uint32) (*progInfo, error) {
 	var info progInfo
-	err := getObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info))
-	return &info, errors.Wrap(err, "can't get info for program")
+	err := getObjectInfoByFD(uint32(fd), unsafe.Pointer(&info), unsafe.Sizeof(info))
+	return &info, errors.Wrap(err, "can't get program info")
+}
+
+func getMapInfoByFD(fd uint32) (*mapInfo, error) {
+	var info mapInfo
+	err := getObjectInfoByFD(uint32(fd), unsafe.Pointer(&info), unsafe.Sizeof(info))
+	return &info, errors.Wrap(err, "can't get map info:")
 }
 
 func getMapFDByID(id uint32) (uint32, error) {

--- a/types.go
+++ b/types.go
@@ -8,8 +8,9 @@ type MapType uint32
 
 // All the various map types that can be created
 const (
+	UnspecifiedMap MapType = iota
 	// Hash is a hash map
-	Hash MapType = 1 + iota
+	Hash
 	// Array is an array map
 	Array
 	// ProgramArray - A program array map is a special kind of array map whose map

--- a/types_string.go
+++ b/types_string.go
@@ -4,14 +4,13 @@ package ebpf
 
 import "strconv"
 
-const _MapType_name = "HashArrayProgramArrayPerfEventArrayPerCPUHashPerCPUArrayStackTraceCGroupArrayLRUHashLRUCPUHashLPMTrieArrayOfMapsHashOfMaps"
+const _MapType_name = "UnspecifiedMapHashArrayProgramArrayPerfEventArrayPerCPUHashPerCPUArrayStackTraceCGroupArrayLRUHashLRUCPUHashLPMTrieArrayOfMapsHashOfMaps"
 
-var _MapType_index = [...]uint8{0, 4, 9, 21, 35, 45, 56, 66, 77, 84, 94, 101, 112, 122}
+var _MapType_index = [...]uint8{0, 14, 18, 23, 35, 49, 59, 70, 80, 91, 98, 108, 115, 126, 136}
 
 func (i MapType) String() string {
-	i -= 1
 	if i >= MapType(len(_MapType_index)-1) {
-		return "MapType(" + strconv.FormatInt(int64(i+1), 10) + ")"
+		return "MapType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _MapType_name[_MapType_index[i]:_MapType_index[i+1]]
 }


### PR DESCRIPTION
Allow users to specify an ABI for the various objects. They can then
verify at run time that what they've loaded from an ELF or read from
a pinned object conforms to what they expect.

This cuts down the boilerplate required when the workflow is load spec,
edit spec, create collection. It also provides another seatbelt when
used with LoadPinned* on newer kernels.

Sadly, there is currently no way to figure out what the ABI of an
inner map is. As such, they have to use Load*Explicit for now.

Fixes #33
