### PR TITLE
fix missing ABI for nested maps

### DIFF
--- a/map.go
+++ b/map.go
@@ -50,7 +50,7 @@ func NewMap(spec *MapSpec) (*Map, error) {
 	}
 
 	if spec.InnerMap == nil {
-		return nil, errors.Errorf("map of map requires InnerMap")
+		return nil, errors.Errorf("%s requires InnerMap", spec.Type)
 	}
 
 	template, err := createMap(spec.InnerMap, 0)
@@ -59,16 +59,10 @@ func NewMap(spec *MapSpec) (*Map, error) {
 	}
 	defer template.Close()
 
-	outerSpec := *spec
-	outerSpec.InnerMap = nil
-	return createMap(&outerSpec, template.fd)
+	return createMap(spec, template.fd)
 }
 
 func createMap(spec *MapSpec, inner uint32) (*Map, error) {
-	if spec.InnerMap != nil {
-		return nil, errors.Errorf("inner map not allowed for %s", spec.Type)
-	}
-
 	cpy := *spec
 	switch spec.Type {
 	case ArrayOfMaps:

--- a/map_test.go
+++ b/map_test.go
@@ -177,6 +177,30 @@ func TestMapInMap(t *testing.T) {
 	}
 }
 
+func TestMapInMapABI(t *testing.T) {
+	spec := &MapSpec{
+		Type:       ArrayOfMaps,
+		KeySize:    4,
+		MaxEntries: 2,
+		InnerMap: &MapSpec{
+			Type:       Array,
+			KeySize:    4,
+			ValueSize:  4,
+			MaxEntries: 2,
+		},
+	}
+
+	m, err := NewMap(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	if m.abi.InnerMap == nil {
+		t.Error("ABI is missing InnerMap")
+	}
+}
+
 func TestIterateEmptyMap(t *testing.T) {
 	hash := createHash()
 	defer hash.Close()


### PR DESCRIPTION
Nested maps don't have MapABI.InnerMap set, since we null out MapSpec.InnerMap
before creating the MapABI. This was done due to an abundance of caution, which
bites us now. Stop changing the MapSpec and add a test for the behaviour.

Updates #33