### PR TITLE
add a helper to sanitize map and prog names

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 	"unsafe"
@@ -273,6 +274,22 @@ func LoadPinnedProgramExplicit(fileName string, abi *ProgramABI) (*Program, erro
 		filepath.Base(fileName),
 		*abi,
 	}, nil
+}
+
+// SanitizeName replaces all invalid characters in name.
+//
+// Use this to automatically generate valid names for maps and
+// programs at run time.
+//
+// Passing a negative value for replacement will delete characters
+// instead of replacing them.
+func SanitizeName(name string, replacement rune) string {
+	return strings.Map(func(char rune) rune {
+		if invalidBPFObjNameChar(char) {
+			return replacement
+		}
+		return char
+	}, name)
 }
 
 type loadError struct {

--- a/prog_test.go
+++ b/prog_test.go
@@ -138,3 +138,16 @@ func TestProgramName(t *testing.T) {
 		t.Errorf("Name is not test, got '%s'", name)
 	}
 }
+
+func TestSanitizeName(t *testing.T) {
+	for input, want := range map[string]string{
+		"test":     "test",
+		"t-est":    "test",
+		"t_est":    "t_est",
+		"hörnchen": "hrnchen",
+	} {
+		if have := SanitizeName(input, -1); have != want {
+			t.Errorf("Wanted '%s' got '%s'", want, have)
+		}
+	}
+}

--- a/syscalls.go
+++ b/syscalls.go
@@ -23,21 +23,7 @@ type bpfObjName [bpfObjNameLen]byte
 
 // newBPFObjName truncates the result if it is too long.
 func newBPFObjName(name string) (bpfObjName, error) {
-	idx := strings.IndexFunc(name, func(char rune) bool {
-		switch {
-		case char >= 'A' && char <= 'Z':
-			fallthrough
-		case char >= 'a' && char <= 'z':
-			fallthrough
-		case char >= '0' && char <= '9':
-			fallthrough
-		case char == '_':
-			return false
-		default:
-			return true
-		}
-	})
-
+	idx := strings.IndexFunc(name, invalidBPFObjNameChar)
 	if idx != -1 {
 		return bpfObjName{}, errors.Errorf("invalid character '%c' in name '%s'", name[idx], name)
 	}
@@ -45,6 +31,21 @@ func newBPFObjName(name string) (bpfObjName, error) {
 	var result bpfObjName
 	copy(result[:bpfObjNameLen-1], name)
 	return result, nil
+}
+
+func invalidBPFObjNameChar(char rune) bool {
+	switch {
+	case char >= 'A' && char <= 'Z':
+		fallthrough
+	case char >= 'a' && char <= 'z':
+		fallthrough
+	case char >= '0' && char <= '9':
+		fallthrough
+	case char == '_':
+		return false
+	default:
+		return true
+	}
 }
 
 type bpfMapCreateAttr struct {


### PR DESCRIPTION
It's sometimes useful to generate new names for maps or programs at
run time. These names need to avoid invalid characters to not be
rejected by the kernel. Add a function which suitably sanitizes input.
