### PR TITLE
perf: Create ring for online, not possible CPUs

### DIFF
--- a/perf.go
+++ b/perf.go
@@ -219,7 +219,8 @@ func NewPerfReader(opts PerfReaderOptions) (out *PerfReader, err error) {
 		return nil, errors.New("PerCPUBuffer must be larger than 0")
 	}
 
-	nCPU, err := possibleCPUs()
+	// We can't create a ring for CPUs that aren't online, so use only the online (of possible) CPUs
+	nCPU, err := onlineCPUs()
 	if err != nil {
 		return nil, errors.Wrap(err, "sampled perf event")
 	}


### PR DESCRIPTION
Creating perf rings for CPUs that are "possible" but not "online"
(see https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu)
fails with:

    failed to create perf ring for CPU 64: this processor architecture
    does not support this event type

Determine the number of CPUs from the "online" ones.
We only support parsing continuous 0 indexed ranges of CPU numbers, but
the sysfs files can potentially contain multiple ranges (see get_nproc()
in glibc), as this means we can use a simple cpu count and not worry
about the ids / numbers.
