### PR TITLE
Allow controlling the verifier log buffer

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -8,6 +8,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CollectionOptions control loading a collection into the kernel.
+type CollectionOptions struct {
+	Programs ProgramOptions
+}
+
 // CollectionSpec describes a collection.
 type CollectionSpec struct {
 	Maps     map[string]*MapSpec
@@ -36,6 +41,13 @@ type Collection struct {
 //
 // Only maps referenced by at least one of the programs are initialized.
 func NewCollection(spec *CollectionSpec) (*Collection, error) {
+	return NewCollectionWithOptions(spec, CollectionOptions{})
+}
+
+// NewCollectionWithOptions creates a Collection from a specification.
+//
+// Only maps referenced by at least one of the programs are initialized.
+func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (*Collection, error) {
 	maps := make(map[string]*Map)
 	for mapName, mapSpec := range spec.Maps {
 		m, err := NewMap(mapSpec)
@@ -61,7 +73,7 @@ func NewCollection(spec *CollectionSpec) (*Collection, error) {
 			}
 		}
 
-		prog, err := NewProgram(progSpec)
+		prog, err := NewProgramWithOptions(progSpec, opts.Programs)
 		if err != nil {
 			return nil, errors.Wrapf(err, "program %s", progName)
 		}

--- a/syscalls.go
+++ b/syscalls.go
@@ -371,5 +371,8 @@ func newEpollFd(fds ...int) (int, error) {
 
 func convertCString(in []byte) string {
 	inLen := bytes.IndexByte(in, 0)
+	if inLen == -1 {
+		return ""
+	}
 	return string(in[:inLen])
 }


### PR DESCRIPTION
So far we've hardcoded the buffer size passed to the in kernel verifier. This is OK,
because by default we do not enable logging. Only when loading a program fails do
we re-run with logging enabled. But since there is no way to change the size of the
buffer users can get into a situation where they can't get debug output without
changing the source.

Add an API that allows users to control both the log level and log size independently.