### PR TITLE
fix example_sock_extract_dist_test.go

### DIFF
--- a/example_sock_extract_dist_test.go
+++ b/example_sock_extract_dist_test.go
@@ -99,7 +99,7 @@ func attachBPF(fd int) (*ebpf.Map, error) {
 		asm.LoadMem(asm.R0, asm.R1, 16, asm.Word),
 
 		// Perhaps ipv6
-		asm.LoadImm(asm.R2, int64(ETH_P_IPV6), asm.Half),
+		asm.LoadImm(asm.R2, int64(ETH_P_IPV6), asm.DWord),
 		asm.HostTo(asm.BE, asm.R2, asm.Half),
 		asm.JEq.Reg(asm.R0, asm.R2, "ipv6"),
 
@@ -133,7 +133,7 @@ func attachBPF(fd int) (*ebpf.Map, error) {
 
 		// MapUpdate
 		// r1 has map ptr
-		asm.LoadImm(asm.R1, int64(ttls.FD()), asm.DWord),
+		asm.LoadImm(asm.R1, int64(ttls.FD()), asm.DWord).Sym("update-map"),
 		// r2 has key -> &FP[-4]
 		asm.Mov.Reg(asm.R2, asm.RFP),
 		asm.Add.Imm(asm.R2, -4),
@@ -177,9 +177,10 @@ func detachBPF(fd int) error {
 
 func minDistance(ttls *ebpf.Map) (int, error) {
 	var (
-		entries      = ttls.Iterate()
-		ttl, minDist uint32
-		count        uint64
+		entries = ttls.Iterate()
+		ttl     uint32
+		minDist uint32 = 255
+		count   uint64
 	)
 	for entries.Next(&ttl, &count) {
 		var dist uint32


### PR DESCRIPTION
fix some small error in  example_sock_extract_dist_test.go

* add missing Sym label update-map
* initialise minDist,
* change 2 ebpf insruction in DWord load instead of word

from the last one i don't know why this is needed. If i don't i get the error:
```
 panic: failed to load program: invalid argument: unknown opcode 00        
```
The errors originates from `pfProgLoad `. I get similar result with other sizes, only DWord works.
with Byte
```
panic: failed to load program: invalid argument: unknown opcode 10  
```
with Half
```
panic: faiLed to load program: invalid argument: unknown opcode 08    
```
I don't understand yet why/ how this works. But With these change i verified that it works correct. Maybe if i have more time I will look in to It.
To get it to work you also need the changes i described in #88 to run correctly 
