### PR TITLE
Add LoadMapPtr

### DIFF
--- a/asm/load_store.go
+++ b/asm/load_store.go
@@ -97,6 +97,16 @@ func LoadImm(dst Register, value int64, size Size) Instruction {
 	}
 }
 
+// LoadMapPtr stores a pointer to a map in dst.
+func LoadMapPtr(dst Register, fd int) Instruction {
+	return Instruction{
+		OpCode:   LoadImmOp(DWord),
+		Dst:      dst,
+		Src:      R1,
+		Constant: int64(fd),
+	}
+}
+
 // LoadIndOp returns the OpCode for loading a value of given size from an sk_buff.
 func LoadIndOp(size Size) OpCode {
 	return OpCode(LdClass).SetMode(IndMode).SetSize(size)

--- a/example_sock_elf_test.go
+++ b/example_sock_elf_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/newtools/ebpf"
-	"github.com/newtools/zsocket/nettypes"
 )
 
 var program = [...]byte{
@@ -112,40 +111,55 @@ func Example_socketELF() {
 			panic(err)
 		}
 	}
+	defer coll.Close()
+
 	sock, err := openRawSock(*index)
 	if err != nil {
 		panic(err)
 	}
-	prog, ok := coll.Programs["bpf_prog1"]
-	if !ok {
-		panic(fmt.Errorf("no program named \"bpf_prog1\" found"))
+	defer syscall.Close(sock)
+
+	prog := coll.DetachProgram("bpf_prog1")
+	if prog == nil {
+		panic("no program named bpf_prog1 found")
 	}
+	defer prog.Close()
+
 	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, SO_ATTACH_BPF, prog.FD()); err != nil {
 		panic(err)
 	}
 
 	fmt.Printf("Filtering on eth index: %d\n", *index)
 	fmt.Println("Packet stats:")
-	bpfMap, ok := coll.Maps["my_map"]
-	if !ok {
-		panic(fmt.Errorf("no map named \"my_map\" found"))
+
+	protoStats := coll.DetachMap("my_map")
+	if protoStats == nil {
+		panic(fmt.Errorf("no map named my_map found"))
 	}
+	defer protoStats.Close()
+
 	for {
+		const (
+			ICMP = 0x01
+			TCP  = 0x06
+			UDP  = 0x11
+		)
+
 		time.Sleep(time.Second)
 		var icmp uint64
 		var tcp uint64
 		var udp uint64
-		ok, err := bpfMap.Get(uint32(nettypes.ICMP), &icmp)
+		ok, err := protoStats.Get(uint32(ICMP), &icmp)
 		if err != nil {
 			panic(err)
 		}
 		assertTrue(ok, "icmp key not found")
-		ok, err = bpfMap.Get(uint32(nettypes.TCP), &tcp)
+		ok, err = protoStats.Get(uint32(TCP), &tcp)
 		if err != nil {
 			panic(err)
 		}
 		assertTrue(ok, "tcp key not found")
-		ok, err = bpfMap.Get(uint32(nettypes.UDP), &udp)
+		ok, err = protoStats.Get(uint32(UDP), &udp)
 		if err != nil {
 			panic(err)
 		}

--- a/example_sock_extract_dist_test.go
+++ b/example_sock_extract_dist_test.go
@@ -122,7 +122,7 @@ func attachBPF(fd int) (*ebpf.Map, error) {
 		asm.Add.Imm(asm.R2, -4),
 
 		// r1 must point to map
-		asm.LoadImm(asm.R1, int64(ttls.FD()), asm.DWord),
+		asm.LoadMapPtr(asm.R1, ttls.FD()),
 		asm.MapLookupElement.Call(),
 
 		// load ok? inc. Otherwise? jmp to mapupdate
@@ -133,7 +133,7 @@ func attachBPF(fd int) (*ebpf.Map, error) {
 
 		// MapUpdate
 		// r1 has map ptr
-		asm.LoadImm(asm.R1, int64(ttls.FD()), asm.DWord).Sym("update-map"),
+		asm.LoadMapPtr(asm.R1, ttls.FD()).Sym("update-map"),
 		// r2 has key -> &FP[-4]
 		asm.Mov.Reg(asm.R2, asm.RFP),
 		asm.Add.Imm(asm.R2, -4),

--- a/example_sock_test.go
+++ b/example_sock_test.go
@@ -63,7 +63,7 @@ func Example_socket() {
 		asm.Add.Imm(asm.R2, -4),
 		// load the map fd into memory, in argument 1 position
 		// lddw reg1, (*:from_user_space)(imm)
-		asm.LoadImm(asm.R1, int64(mapFd), asm.DWord),
+		asm.LoadMapPtr(asm.R1, protoStats.FD()),
 		// call map lookup -> map_lookup_elem(r1, r2)
 		// call imm
 		asm.MapLookupElement.Call(),

--- a/example_sock_test.go
+++ b/example_sock_test.go
@@ -11,11 +11,9 @@ import (
 
 	"github.com/newtools/ebpf"
 	"github.com/newtools/ebpf/asm"
-	"github.com/newtools/zsocket/inet"
-	"github.com/newtools/zsocket/nettypes"
 )
 
-type IPHdr struct {
+var ipHdr struct {
 	VersionIHL     uint8
 	Tos            uint8
 	Length         uint16
@@ -26,10 +24,9 @@ type IPHdr struct {
 	Checksum       uint16
 	SrcIP          [4]byte
 	DestIP         [4]byte
-	PayloadLength  int
 }
 
-const EthHLen = 14
+const ethHLen = 14
 
 // ExampleSocket demonstrates how to attach an EBPF program
 // to a socket.
@@ -38,7 +35,8 @@ func Example_socket() {
 
 	index := flag.Int("index", 0, "specify ethernet index")
 	flag.Parse()
-	bpfMap, err := ebpf.NewMap(&ebpf.MapSpec{
+
+	protoStats, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Array,
 		KeySize:    4,
 		ValueSize:  8,
@@ -47,13 +45,13 @@ func Example_socket() {
 	if err != nil {
 		panic(err)
 	}
-	ip := IPHdr{}
-	mapFd := bpfMap.FD()
-	ebpfInss := asm.Instructions{
+	defer protoStats.Close()
+
+	inss := asm.Instructions{
 		// move context to R6 for LoadAbs
 		asm.Mov.Reg(asm.R6, asm.R1),
 		// get ip protocol
-		asm.LoadAbs(int32(EthHLen+unsafe.Offsetof(ip.Protocol)), asm.Byte),
+		asm.LoadAbs(int32(ethHLen+unsafe.Offsetof(ipHdr.Protocol)), asm.Byte),
 		// set 4 bytes off the frame pointer to be equal to r0
 		asm.StoreMem(asm.RFP, -4, asm.R0, asm.Word),
 		// set 2nd arg (to be given to map fx below) to current FP
@@ -82,45 +80,53 @@ func Example_socket() {
 		// exit
 		asm.Return(),
 	}
-	bpfProgram, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Type:         ebpf.SocketFilter,
 		License:      "GPL",
-		Instructions: ebpfInss,
+		Instructions: inss,
 	})
-
 	if err != nil {
-		fmt.Printf("%s\n", ebpfInss)
 		panic(err)
 	}
+	defer prog.Close()
+
 	sock, err := openRawSock(*index)
 	if err != nil {
 		panic(err)
 	}
-	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, SO_ATTACH_BPF, bpfProgram.FD()); err != nil {
+	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, SO_ATTACH_BPF, prog.FD()); err != nil {
 		panic(err)
 	}
+
 	fmt.Printf("Filtering on eth index: %d\n", *index)
 	fmt.Println("Packet stats:")
 	for {
+		const (
+			ICMP = 0x01
+			TCP  = 0x06
+			UDP  = 0x11
+		)
+
 		time.Sleep(time.Second)
 		var icmp uint64
 		var tcp uint64
 		var udp uint64
-		ok, err := bpfMap.Get(uint32(nettypes.ICMP), &icmp)
+		ok, err := protoStats.Get(uint32(ICMP), &icmp)
 		if err != nil {
 			panic(err)
 		}
 		if !ok {
 			icmp = 0
 		}
-		ok, err = bpfMap.Get(uint32(nettypes.TCP), &tcp)
+		ok, err = protoStats.Get(uint32(TCP), &tcp)
 		if err != nil {
 			panic(err)
 		}
 		if !ok {
 			tcp = 0
 		}
-		ok, err = bpfMap.Get(uint32(nettypes.UDP), &udp)
+		ok, err = protoStats.Get(uint32(UDP), &udp)
 		if err != nil {
 			panic(err)
 		}
@@ -132,13 +138,13 @@ func Example_socket() {
 }
 
 func openRawSock(index int) (int, error) {
-	eT := inet.HToNS(nettypes.All[:])
-	sock, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC, int(eT))
+	const ETH_P_ALL uint16 = 0x00<<8 | 0x03
+	sock, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC, int(ETH_P_ALL))
 	if err != nil {
 		return 0, err
 	}
 	sll := syscall.SockaddrLinklayer{}
-	sll.Protocol = eT
+	sll.Protocol = ETH_P_ALL
 	sll.Ifindex = index
 	if err := syscall.Bind(sock, &sll); err != nil {
 		return 0, err


### PR DESCRIPTION
Loading a map pointer from an fd into a register requires that the source register in the opcode is R1. Wrap this magic into a dedicated helper function, to be used with MapLookupElement, etc.
