### PR TITLE
Use Go 1.11 in CI

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -77,8 +77,9 @@ for kernel_version in "${kernel_versions[@]}"; do
     --volume=go,kind=host,source="/home/runner/workspace" \
     --mount=volume=src,target="${SEMAPHORE_PROJECT_DIR}" \
     --mount=volume=go,target="/go" \
-    docker://golang:1.10-alpine \
+    docker://golang:1.11-alpine \
     --environment=GOPATH=/go \
+    --environment=CGO_ENABLED=0 \
     --exec=/bin/sh -- -c \
     "mount -t tmpfs tmpfs /tmp &&
       mount -t bpf bpf /sys/fs/bpf &&


### PR DESCRIPTION
Update to current stable version of Go. Needs CGO_ENABLED=0, because the build otherwise fails due to missing gcc.