### PR TITLE
asm: Add <, <= jump ops, remove unknown JSE

### DIFF
--- a/asm/jump.go
+++ b/asm/jump.go
@@ -24,18 +24,26 @@ const (
 	JGT JumpOp = 0x20
 	// JGE jumps by offset if r >= imm
 	JGE JumpOp = 0x30
-	// JSE jumps by offset if signed r == signed imm
-	JSE JumpOp = 0x40
-	// JNE jumps by offset if r != imm, eBPF only
+	// JSet jumps by offset if r & imm
+	JSet JumpOp = 0x40
+	// JNE jumps by offset if r != imm
 	JNE JumpOp = 0x50
-	// JSGT jumps by offset if signed r > signed imm, eBPF only
+	// JSGT jumps by offset if signed r > signed imm
 	JSGT JumpOp = 0x60
-	// JSGE jumps by offset if signed r >= signed imm, eBPF only
+	// JSGE jumps by offset if signed r >= signed imm
 	JSGE JumpOp = 0x70
-	// Call builtin or user defined function from imm, eBPF only
+	// Call builtin or user defined function from imm
 	Call JumpOp = 0x80
 	// Exit ends execution, with value in r0
 	Exit JumpOp = 0x90
+	// JLT jumps by offset if r < imm
+	JLT JumpOp = 0xa0
+	// JLE jumps by offset if r <= imm
+	JLE JumpOp = 0xb0
+	// JSLT jumps by offset if signed r < signed imm
+	JSLT JumpOp = 0xc0
+	// JSLE jumps by offset if signed r <= signed imm
+	JSLE JumpOp = 0xd0
 )
 
 // Return emits an exit instruction.

--- a/asm/jump_string.go
+++ b/asm/jump_string.go
@@ -4,20 +4,24 @@ package asm
 
 import "strconv"
 
-const _JumpOp_name = "JaJEqJGTJGEJSEJNEJSGTJSGECallExitInvalidJumpOp"
+const _JumpOp_name = "JaJEqJGTJGEJSetJNEJSGTJSGECallExitJLTJLEJSLTJSLEInvalidJumpOp"
 
 var _JumpOp_map = map[JumpOp]string{
 	0:   _JumpOp_name[0:2],
 	16:  _JumpOp_name[2:5],
 	32:  _JumpOp_name[5:8],
 	48:  _JumpOp_name[8:11],
-	64:  _JumpOp_name[11:14],
-	80:  _JumpOp_name[14:17],
-	96:  _JumpOp_name[17:21],
-	112: _JumpOp_name[21:25],
-	128: _JumpOp_name[25:29],
-	144: _JumpOp_name[29:33],
-	255: _JumpOp_name[33:46],
+	64:  _JumpOp_name[11:15],
+	80:  _JumpOp_name[15:18],
+	96:  _JumpOp_name[18:22],
+	112: _JumpOp_name[22:26],
+	128: _JumpOp_name[26:30],
+	144: _JumpOp_name[30:34],
+	160: _JumpOp_name[34:37],
+	176: _JumpOp_name[37:40],
+	192: _JumpOp_name[40:44],
+	208: _JumpOp_name[44:48],
+	255: _JumpOp_name[48:61],
 }
 
 func (i JumpOp) String() string {


### PR DESCRIPTION
Add JumpLessThan, JumpLessOrEqual, and their signed friends.

Remove JumpSignedEqual as it's not an eBPF instruction. The opcode it
used (0x40) is actually JumpBitsSet. Add that instead.

Update strings with stringer.
