### PR TITLE
 Expose Map and Program ABI

### DIFF
--- a/map.go
+++ b/map.go
@@ -144,6 +144,11 @@ func (m *Map) String() string {
 	return fmt.Sprintf("%s#%d", m.abi.Type, m.fd)
 }
 
+// ABI gets the ABI of the Map
+func (m *Map) ABI() MapABI {
+	return m.abi
+}
+
 // Get gets a value from a Map
 func (m *Map) Get(key, valueOut interface{}) (bool, error) {
 	valueBytes, err := m.GetBytes(key)

--- a/perf_test.go
+++ b/perf_test.go
@@ -149,7 +149,7 @@ func TestPerfReaderFlushAndClose(t *testing.T) {
 	defer prog.Close()
 
 	// more samples than the channel capacity
-	numSamples := cap(rd.Samples)*2
+	numSamples := cap(rd.Samples) * 2
 	for i := 0; i < numSamples; i++ {
 		ret, _, err := prog.Test(make([]byte, 14))
 		if err != nil {
@@ -162,7 +162,7 @@ func TestPerfReaderFlushAndClose(t *testing.T) {
 	}
 
 	done := make(chan struct{})
-	go func(){
+	go func() {
 		rd.FlushAndClose()
 		// Should be able to call this multiple times
 		rd.FlushAndClose()

--- a/prog.go
+++ b/prog.go
@@ -167,6 +167,11 @@ func (bpf *Program) String() string {
 	return fmt.Sprintf("%s#%d", bpf.abi.Type, bpf.fd)
 }
 
+// ABI gets the ABI of the Program
+func (bpf *Program) ABI() ProgramABI {
+	return bpf.abi
+}
+
 // FD gets the file descriptor value of the Program
 func (bpf *Program) FD() int {
 	return int(bpf.fd)


### PR DESCRIPTION
Expose the ABI of existing / loaded maps and programs. This is useful
when loading pinned maps or programs, so that interesting bits of the
ABI (such as the type or map max entries).