### PR TITLE
Improve Map and Program unmarshaling

### DIFF
--- a/map.go
+++ b/map.go
@@ -181,6 +181,20 @@ func (m *Map) Get(key, valueOut interface{}) (bool, error) {
 	case Map:
 		return true, errors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
 
+	case **Program:
+		p, err := unmarshalProgram(valueBytes)
+		if err != nil {
+			return true, err
+		}
+
+		(*value).Close()
+		*value = p
+		return true, nil
+	case *Program:
+		return true, errors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+	case Program:
+		return true, errors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+
 	default:
 		return true, unmarshalBytes(valueOut, valueBytes)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -256,38 +256,37 @@ func TestMapIterate(t *testing.T) {
 	}
 }
 
-func TestMapIterateMap(t *testing.T) {
+func TestIterateMapInMap(t *testing.T) {
+	const idx = uint32(1)
+
 	parent := createMapInMap(t, ArrayOfMaps)
 	defer parent.Close()
 
 	a := createArray(t)
 	defer a.Close()
 
-	if err := parent.Put(uint32(0), a); err != nil {
+	if err := parent.Put(idx, a); err != nil {
 		t.Fatal(err)
 	}
 
-	var key uint32
-	var m *Map
+	var (
+		key     uint32
+		m       *Map
+		entries = parent.Iterate()
+	)
 	defer m.Close()
 
-	entries := parent.Iterate()
 	if !entries.Next(&key, &m) {
 		t.Fatal("Iterator encountered error:", entries.Err())
+	}
+
+	if key != 1 {
+		t.Error("Iterator didn't skip first entry")
 	}
 
 	if m == nil {
 		t.Fatal("Map is nil")
 	}
-
-	entries = parent.Iterate()
-	if entries.Next(&key, m) {
-		t.Fatal("Iterator should return false if used with incorrect map type")
-	}
-	if entries.Err() == nil {
-		t.Fatal("Iterator should return an error if used with incorrect map type")
-	}
-
 }
 
 func TestPerCPUMarshaling(t *testing.T) {

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -30,10 +30,12 @@ func ExampleMarshaler() {
 		panic(err)
 	}
 
-	var key customEncoding
-	var value uint32
+	var (
+		key     customEncoding
+		value   uint32
+		entries = hash.Iterate()
+	)
 
-	entries := hash.Iterate()
 	for entries.Next(&key, &value) {
 		fmt.Printf("key: %s, value: %d\n", key.data, value)
 	}

--- a/marshalers.go
+++ b/marshalers.go
@@ -55,7 +55,7 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	}
 
 	if len(buf) != length {
-		return nil, errors.Errorf("%T must marshal to %d bytes", data, length)
+		return nil, errors.Errorf("%T doesn't marshal to %d bytes", data, length)
 	}
 	return buf, nil
 }

--- a/syscalls.go
+++ b/syscalls.go
@@ -267,6 +267,15 @@ func bpfGetMapFDByID(id uint32) (uint32, error) {
 	return uint32(ptr), errors.Wrapf(err, "can't get fd for map id %d", id)
 }
 
+func bpfGetProgramFDByID(id uint32) (uint32, error) {
+	// available from 4.13
+	attr := bpfGetFDByIDAttr{
+		id: id,
+	}
+	ptr, err := bpfCall(_ProgGetFDByID, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
+	return uint32(ptr), errors.Wrapf(err, "can't get fd for program id %d", id)
+}
+
 type wrappedErrno struct {
 	errNo   syscall.Errno
 	message string


### PR DESCRIPTION
* map: fix unsafe unmarshaling

    Map currently implements BinaryUnmarshaler, which retrieves a file
    descriptor from a map id. This allows code like the following:

        var m Map
        othermap.Get(uint32(0), &m)

    There is a bug in the implementation which means that m will not
    have a finalizer set on it, which means that code like this will
    leak the file descriptor if m.Close() isn't called.

    To fix the bug, we forbid unmarshalling into a Map. Instead
    callers will have to provide a **Map:

        var m *Map
        othermap.Get(uint32(0), &m

    This is more in line with the rest of the API, and is simpler than
    trying to make sure that Map is valid without going through a
    constructor. It also has the benefit that iterating over a map of
    maps works without leaving unused *Map around.

* program: support unmarshaling from ProgramArray

    It's currently possible to add a Program to a ProgramArray by
    putting uint32(Program.FD()) into a map. However, it's not
    possible to unmarshal the same program.

    Add functionality analogous to *Map to allow unmarshalling into
    a *Program. Also fix LoadPinnedProgram* not properly setting
    the finalizer.