### PR TITLE
Don't modify CollectionSpec in NewCollection*

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -19,6 +19,28 @@ type CollectionSpec struct {
 	Programs map[string]*ProgramSpec
 }
 
+// Copy returns a recursive copy of the spec.
+func (cs *CollectionSpec) Copy() *CollectionSpec {
+	if cs == nil {
+		return nil
+	}
+
+	cpy := CollectionSpec{
+		Maps:     make(map[string]*MapSpec, len(cs.Maps)),
+		Programs: make(map[string]*ProgramSpec, len(cs.Programs)),
+	}
+
+	for name, spec := range cs.Maps {
+		cpy.Maps[name] = spec.Copy()
+	}
+
+	for name, spec := range cs.Programs {
+		cpy.Programs[name] = spec.Copy()
+	}
+
+	return &cpy
+}
+
 // LoadCollectionSpec parse an object file and convert it to a collection
 func LoadCollectionSpec(file string) (*CollectionSpec, error) {
 	f, err := os.Open(file)
@@ -59,7 +81,7 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (*Co
 
 	progs := make(map[string]*Program)
 	for progName, origProgSpec := range spec.Programs {
-		progSpec := origProgSpec.copy()
+		progSpec := origProgSpec.Copy()
 		editor := Edit(&progSpec.Instructions)
 
 		// Rewrite any Symbol which is a valid Map.

--- a/collection.go
+++ b/collection.go
@@ -58,7 +58,8 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (*Co
 	}
 
 	progs := make(map[string]*Program)
-	for progName, progSpec := range spec.Programs {
+	for progName, origProgSpec := range spec.Programs {
+		progSpec := origProgSpec.copy()
 		editor := Edit(&progSpec.Instructions)
 
 		// Rewrite any Symbol which is a valid Map.

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,0 +1,43 @@
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/newtools/ebpf/asm"
+)
+
+func TestCollectionSpecNotModified(t *testing.T) {
+	cs := CollectionSpec{
+		Maps: map[string]*MapSpec{
+			"my-map": {
+				Type:       Array,
+				KeySize:    4,
+				ValueSize:  4,
+				MaxEntries: 1,
+			},
+		},
+		Programs: map[string]*ProgramSpec{
+			"test": {
+				Type: SocketFilter,
+				Instructions: asm.Instructions{
+					asm.LoadMapPtr(asm.R1, 0),
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					asm.Return(),
+				},
+				License: "MIT",
+			},
+		},
+	}
+
+	cs.Programs["test"].Instructions[0].Reference = "my-map"
+
+	coll, err := NewCollection(&cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coll.Close()
+
+	if cs.Programs["test"].Instructions[0].Constant != 0 {
+		t.Error("Creating a collection modifies input spec")
+	}
+}

--- a/collection_test.go
+++ b/collection_test.go
@@ -41,3 +41,40 @@ func TestCollectionSpecNotModified(t *testing.T) {
 		t.Error("Creating a collection modifies input spec")
 	}
 }
+
+func TestCollectionSpecCopy(t *testing.T) {
+	cs := &CollectionSpec{
+		Maps: map[string]*MapSpec{
+			"my-map": {
+				Type:       Array,
+				KeySize:    4,
+				ValueSize:  4,
+				MaxEntries: 1,
+			},
+		},
+		Programs: map[string]*ProgramSpec{
+			"test": {
+				Type: SocketFilter,
+				Instructions: asm.Instructions{
+					asm.LoadMapPtr(asm.R1, 0),
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					asm.Return(),
+				},
+				License: "MIT",
+			},
+		},
+	}
+	cpy := cs.Copy()
+
+	if cpy == cs {
+		t.Error("Copy returned the same pointner")
+	}
+
+	if cpy.Maps["my-map"] == cs.Maps["my-map"] {
+		t.Error("Copy returned same Maps")
+	}
+
+	if cpy.Programs["test"] == cs.Programs["test"] {
+		t.Error("Copy returned same Programs")
+	}
+}

--- a/elf.go
+++ b/elf.go
@@ -234,7 +234,7 @@ func (ec *elfCode) loadMaps(mapSections map[int]*elf.Section) (map[string]*MapSp
 				if innerSpec.InnerMap != nil {
 					return nil, errors.Errorf("map %v: can't nest map of map", name)
 				}
-				spec.InnerMap = innerSpec
+				spec.InnerMap = innerSpec.Copy()
 			}
 
 			maps[name] = &spec

--- a/map.go
+++ b/map.go
@@ -27,6 +27,17 @@ func (ms *MapSpec) String() string {
 	return fmt.Sprintf("%s(keySize=%d, valueSize=%d, maxEntries=%d, flags=%d)", ms.Type, ms.KeySize, ms.ValueSize, ms.MaxEntries, ms.Flags)
 }
 
+// Copy returns a copy of the spec.
+func (ms *MapSpec) Copy() *MapSpec {
+	if ms == nil {
+		return nil
+	}
+
+	cpy := *ms
+	cpy.InnerMap = ms.InnerMap.Copy()
+	return &cpy
+}
+
 // Map represents a Map file descriptor.
 //
 // Methods which take interface{} arguments by default encode

--- a/prog.go
+++ b/prog.go
@@ -84,10 +84,6 @@ func NewProgram(spec *ProgramSpec) (*Program, error) {
 // Loading a program for the first time will perform
 // feature detection by loading small, temporary programs.
 func NewProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, error) {
-	if len(spec.Instructions) == 0 {
-		return nil, errors.Errorf("instructions cannot be empty")
-	}
-
 	attr, err := convertProgramSpec(spec, haveObjName.Result())
 	if err != nil {
 		return nil, err
@@ -144,6 +140,14 @@ func newProgram(fd uint32, name string, abi *ProgramABI) *Program {
 }
 
 func convertProgramSpec(spec *ProgramSpec, includeName bool) (*bpfProgLoadAttr, error) {
+	if len(spec.Instructions) == 0 {
+		return nil, errors.New("Instructions cannot be empty")
+	}
+
+	if len(spec.License) == 0 {
+		return nil, errors.New("License cannot be empty")
+	}
+
 	buf := bytes.NewBuffer(make([]byte, 0, len(spec.Instructions)*asm.InstructionSize))
 	err := spec.Instructions.Marshal(buf, nativeEndian)
 	if err != nil {

--- a/prog.go
+++ b/prog.go
@@ -53,7 +53,12 @@ type ProgramSpec struct {
 	KernelVersion uint32
 }
 
-func (ps *ProgramSpec) copy() *ProgramSpec {
+// Copy returns a copy of the spec.
+func (ps *ProgramSpec) Copy() *ProgramSpec {
+	if ps == nil {
+		return nil
+	}
+
 	cpy := *ps
 	cpy.Instructions = make(asm.Instructions, len(ps.Instructions))
 	copy(cpy.Instructions, ps.Instructions)

--- a/prog.go
+++ b/prog.go
@@ -53,6 +53,13 @@ type ProgramSpec struct {
 	KernelVersion uint32
 }
 
+func (ps *ProgramSpec) copy() *ProgramSpec {
+	cpy := *ps
+	cpy.Instructions = make(asm.Instructions, len(ps.Instructions))
+	copy(cpy.Instructions, ps.Instructions)
+	return &cpy
+}
+
 // Program represents a Program file descriptor
 type Program struct {
 	// Contains the output of the kernel verifier if enabled,


### PR DESCRIPTION
NewCollection currently modifies its input if there are maps
that need replacing. This is surprising, and breaks a workflow where
a user loads a collection multiple times.

Add a Copy method to Spec types, and fix LoadCollection* not copying the InnerMap specs.

Also fix a panic due to not checking ProgramSpec.License length.
