### PR TITLE
ebpf: allow cloning programs and maps

### DIFF
--- a/map.go
+++ b/map.go
@@ -344,6 +344,18 @@ func (m *Map) FD() int {
 	return int(m.fd)
 }
 
+// Clone creates a duplicate of the Map.
+//
+// Closing the duplicate does not affect the original, and vice versa.
+// Changes made to the map are reflected by both instances however.
+func (m *Map) Clone() (*Map, error) {
+	dupfd, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(m.fd), syscall.F_DUPFD_CLOEXEC, 0)
+	if errno != 0 {
+		return nil, errors.Wrap(errno, "can't dup fd")
+	}
+	return newMap(uint32(dupfd), &m.abi)
+}
+
 // Pin persists the map past the lifetime of the process that created it.
 //
 // This requires bpffs to be mounted above fileName. See http://cilium.readthedocs.io/en/doc-1.0/kubernetes/install/#mounting-the-bpf-fs-optional

--- a/map_test.go
+++ b/map_test.go
@@ -35,6 +35,15 @@ func TestMap(t *testing.T) {
 		t.Fatal("Can't put:", err)
 	}
 
+	m2, err := m.Clone()
+	if err != nil {
+		t.Fatal("Can't clone map:", err)
+	}
+	defer m2.Close()
+
+	m.Close()
+	m = m2
+
 	var v uint32
 	if ok, err := m.Get(uint32(0), &v); err != nil {
 		t.Fatal("Can't get:", err)

--- a/prog_test.go
+++ b/prog_test.go
@@ -47,6 +47,15 @@ func TestProgramRun(t *testing.T) {
 	}
 	defer prog.Close()
 
+	p2, err := prog.Clone()
+	if err != nil {
+		t.Fatal("Can't clone program")
+	}
+	defer p2.Close()
+
+	prog.Close()
+	prog = p2
+
 	ret, out, err := prog.Test(buf)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
It's sometimes useful to get a new handle for a map or program
which can't be invalidated by another piece of code.

Provide the ability to clone / dup() programs and maps.
