### PR TITLE
ebpf: allow Cloning nil Map and Program

### DIFF
--- a/map.go
+++ b/map.go
@@ -348,7 +348,13 @@ func (m *Map) FD() int {
 //
 // Closing the duplicate does not affect the original, and vice versa.
 // Changes made to the map are reflected by both instances however.
+//
+// Cloning a nil Map returns nil.
 func (m *Map) Clone() (*Map, error) {
+	if m == nil {
+		return nil, nil
+	}
+
 	dupfd, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(m.fd), syscall.F_DUPFD_CLOEXEC, 0)
 	if errno != 0 {
 		return nil, errors.Wrap(errno, "can't dup fd")

--- a/map_test.go
+++ b/map_test.go
@@ -65,6 +65,17 @@ func TestMap(t *testing.T) {
 	}
 }
 
+func TestMapCloneNil(t *testing.T) {
+	m, err := (*Map)(nil).Clone()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m != nil {
+		t.Fatal("Cloning a nil map doesn't return nil")
+	}
+}
+
 func TestMapPin(t *testing.T) {
 	m := createArray(t)
 	defer m.Close()

--- a/prog.go
+++ b/prog.go
@@ -201,7 +201,13 @@ func (bpf *Program) FD() int {
 // Clone creates a duplicate of the Program.
 //
 // Closing the duplicate does not affect the original, and vice versa.
+//
+// Cloning a nil Program returns nil.
 func (bpf *Program) Clone() (*Program, error) {
+	if bpf == nil {
+		return nil, nil
+	}
+
 	dupfd, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(bpf.fd), syscall.F_DUPFD_CLOEXEC, 0)
 	if errno != 0 {
 		return nil, errors.Wrap(errno, "can't dup fd")

--- a/prog_test.go
+++ b/prog_test.go
@@ -186,6 +186,17 @@ func TestSanitizeName(t *testing.T) {
 	}
 }
 
+func TestProgramCloneNil(t *testing.T) {
+	p, err := (*Program)(nil).Clone()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if p != nil {
+		t.Fatal("Cloning a nil Program doesn't return nil")
+	}
+}
+
 func TestProgramMarshaling(t *testing.T) {
 	const idx = uint32(0)
 


### PR DESCRIPTION
Just like *Spec.Copy, it's useful to make Cloning a nil Program
and Map well defined.