### PR TITLE
NewCollection: Don't rewrite already rewritten maps

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -91,7 +91,8 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (*Co
 				continue
 			}
 
-			if err := editor.RewriteMap(sym, m); err != nil {
+			// don't overwrite maps already rewritten, users can rewrite programs in the spec themselves
+			if err := editor.rewriteMap(sym, m, false); err != nil {
 				return nil, errors.Wrapf(err, "program %s", progName)
 			}
 		}

--- a/editor.go
+++ b/editor.go
@@ -27,6 +27,10 @@ func Edit(insns *asm.Instructions) *Editor {
 // Use IsUnreferencedSymbol if you want to rewrite potentially
 // unused maps.
 func (ed *Editor) RewriteMap(symbol string, m *Map) error {
+	return ed.rewriteMap(symbol, m, true)
+}
+
+func (ed *Editor) rewriteMap(symbol string, m *Map, overwrite bool) error {
 	indices := ed.ReferenceOffsets[symbol]
 	if len(indices) == 0 {
 		return &unreferencedSymbolError{symbol}
@@ -38,6 +42,10 @@ func (ed *Editor) RewriteMap(symbol string, m *Map) error {
 		load := &(*ed.instructions)[index]
 		if load.OpCode != loadOp {
 			return errors.Errorf("symbol %v: missing load instruction", symbol)
+		}
+
+		if !overwrite && load.Constant != 0 {
+			return nil
 		}
 
 		load.Src = 1


### PR DESCRIPTION
Users can modify programs in a CollectionSpec themselves, for example to
rewrite the Programs to use specific maps.

If the map load instruction has already been rewritten previously, don't
overwrite it again.

Directly rewriting maps in a program using Editor will overwrite any
pre-existing map value.