### PR TITLE
Support AttachType and many more ProgTypes

### DIFF
--- a/elf.go
+++ b/elf.go
@@ -240,7 +240,7 @@ func (ec *elfCode) loadMaps(mapSections map[int]*elf.Section) (map[string]*MapSp
 
 func getProgType(v string) (ProgType, AttachType) {
 	types := map[string]ProgType{
-		// From https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/samples/bpf/bpf_load.c?id=fb40c9ddd66b9c9bb811bbee125b3cb3ba1faee7#n60
+		// From https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/lib/bpf/libbpf.c#n3568
 		"socket":         SocketFilter,
 		"seccomp":        SocketFilter,
 		"kprobe/":        Kprobe,
@@ -266,10 +266,8 @@ func getProgType(v string) (ProgType, AttachType) {
 		"cgroup/sysctl":     CGroupSysctl,
 		"cgroup/getsockopt": CGroupSockopt,
 		"cgroup/setsockopt": CGroupSockopt,
-
-		// From https://github.com/CumulusNetworks/iproute2/blob/6335c5ff67202cf5b39eb929e2a0a5bb133627ba/include/bpf_elf.h#L19
-		"classifier": SchedCLS,
-		"action":     SchedACT,
+		"classifier":        SchedCLS,
+		"action":            SchedACT,
 	}
 	attachTypes := map[string]AttachType{
 		"cgroup_skb/ingress":    AttachCGroupInetIngress,
@@ -296,7 +294,7 @@ func getProgType(v string) (ProgType, AttachType) {
 		"cgroup/getsockopt":     AttachCGroupGetsockopt,
 		"cgroup/setsockopt":     AttachCGroupSetsockopt,
 	}
-	attachType := AttachTypeNone
+	attachType := AttachNone
 	for k, t := range attachTypes {
 		if strings.HasPrefix(v, k) {
 			attachType = t
@@ -308,7 +306,7 @@ func getProgType(v string) (ProgType, AttachType) {
 			return t, attachType
 		}
 	}
-	return Unrecognized, attachType
+	return Unrecognized, AttachNone
 }
 
 func assignSymbols(symbolOffsets map[uint64]*elf.Symbol, insOffsets map[uint64]int, insns asm.Instructions) error {

--- a/elf.go
+++ b/elf.go
@@ -141,7 +141,7 @@ func (ec *elfCode) loadPrograms(progSections, relSections map[int]*elf.Section, 
 			}
 		}
 
-		if progType := getProgType(prog.Name); progType == Unrecognized {
+		if progType, attachType := getProgType(prog.Name); progType == Unrecognized {
 			// There is no single name we can use for "library" sections,
 			// since they may contain multiple functions. We'll decode the
 			// labels they contain later on, and then link sections that way.
@@ -150,6 +150,7 @@ func (ec *elfCode) loadPrograms(progSections, relSections map[int]*elf.Section, 
 			progs[funcSym.Name] = &ProgramSpec{
 				Name:          funcSym.Name,
 				Type:          progType,
+				AttachType:    attachType,
 				License:       license,
 				KernelVersion: version,
 				Instructions:  insns,
@@ -237,28 +238,77 @@ func (ec *elfCode) loadMaps(mapSections map[int]*elf.Section) (map[string]*MapSp
 	return maps, nil
 }
 
-func getProgType(v string) ProgType {
+func getProgType(v string) (ProgType, AttachType) {
 	types := map[string]ProgType{
 		// From https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/samples/bpf/bpf_load.c?id=fb40c9ddd66b9c9bb811bbee125b3cb3ba1faee7#n60
-		"socket":      SocketFilter,
-		"seccomp":     SocketFilter,
-		"kprobe/":     Kprobe,
-		"kretprobe/":  Kprobe,
-		"tracepoint/": TracePoint,
-		"xdp":         XDP,
-		"perf_event":  PerfEvent,
-		"cgroup/skb":  CGroupSKB,
-		"cgroup/sock": CGroupSock,
+		"socket":         SocketFilter,
+		"seccomp":        SocketFilter,
+		"kprobe/":        Kprobe,
+		"kretprobe/":     Kprobe,
+		"tracepoint/":    TracePoint,
+		"xdp":            XDP,
+		"perf_event":     PerfEvent,
+		"sockops":        SockOps,
+		"sk_skb":         SkSKB,
+		"sk_msg":         SkMsg,
+		"lirc_mode2":     LircMode2,
+		"flow_dissector": FlowDissector,
+
+		"cgroup_skb/":       CGroupSKB,
+		"cgroup/dev":        CGroupDevice,
+		"cgroup/skb":        CGroupSKB,
+		"cgroup/sock":       CGroupSock,
+		"cgroup/post_bind":  CGroupSock,
+		"cgroup/bind":       CGroupSockAddr,
+		"cgroup/connect":    CGroupSockAddr,
+		"cgroup/sendmsg":    CGroupSockAddr,
+		"cgroup/recvmsg":    CGroupSockAddr,
+		"cgroup/sysctl":     CGroupSysctl,
+		"cgroup/getsockopt": CGroupSockopt,
+		"cgroup/setsockopt": CGroupSockopt,
+
 		// From https://github.com/CumulusNetworks/iproute2/blob/6335c5ff67202cf5b39eb929e2a0a5bb133627ba/include/bpf_elf.h#L19
 		"classifier": SchedCLS,
 		"action":     SchedACT,
 	}
-	for k, t := range types {
+	attachTypes := map[string]AttachType{
+		"cgroup_skb/ingress":    AttachCGroupInetIngress,
+		"cgroup_skb/egress":     AttachCGroupInetEgress,
+		"cgroup/sock":           AttachCGroupInetSockCreate,
+		"cgroup/post_bind4":     AttachCGroupInet4PostBind,
+		"cgroup/post_bind6":     AttachCGroupInet6PostBind,
+		"cgroup/dev":            AttachCGroupDevice,
+		"sockops":               AttachCGroupSockOps,
+		"sk_skb/stream_parser":  AttachSkSKBStreamParser,
+		"sk_skb/stream_verdict": AttachSkSKBStreamVerdict,
+		"sk_msg":                AttachSkSKBStreamVerdict,
+		"lirc_mode2":            AttachLircMode2,
+		"flow_dissector":        AttachFlowDissector,
+		"cgroup/bind4":          AttachCGroupInet4Bind,
+		"cgroup/bind6":          AttachCGroupInet6Bind,
+		"cgroup/connect4":       AttachCGroupInet4Connect,
+		"cgroup/connect6":       AttachCGroupInet6Connect,
+		"cgroup/sendmsg4":       AttachCGroupUDP4Sendmsg,
+		"cgroup/sendmsg6":       AttachCGroupUDP6Sendmsg,
+		"cgroup/recvmsg4":       AttachCGroupUDP4Recvmsg,
+		"cgroup/recvmsg6":       AttachCGroupUDP6Recvmsg,
+		"cgroup/sysctl":         AttachCGroupSysctl,
+		"cgroup/getsockopt":     AttachCGroupGetsockopt,
+		"cgroup/setsockopt":     AttachCGroupSetsockopt,
+	}
+	attachType := AttachTypeNone
+	for k, t := range attachTypes {
 		if strings.HasPrefix(v, k) {
-			return t
+			attachType = t
 		}
 	}
-	return Unrecognized
+
+	for k, t := range types {
+		if strings.HasPrefix(v, k) {
+			return t, attachType
+		}
+	}
+	return Unrecognized, attachType
 }
 
 func assignSymbols(symbolOffsets map[uint64]*elf.Symbol, insOffsets map[uint64]int, insns asm.Instructions) error {

--- a/prog.go
+++ b/prog.go
@@ -48,6 +48,7 @@ type ProgramSpec struct {
 	// alpha numeric and '_' characters.
 	Name          string
 	Type          ProgType
+	AttachType    AttachType
 	Instructions  asm.Instructions
 	License       string
 	KernelVersion uint32
@@ -164,6 +165,7 @@ func convertProgramSpec(spec *ProgramSpec, includeName bool) (*bpfProgLoadAttr, 
 	lic := []byte(spec.License)
 	attr := &bpfProgLoadAttr{
 		progType:     spec.Type,
+		expectedAttachType: spec.AttachType,
 		insCount:     insCount,
 		instructions: newPtr(unsafe.Pointer(&bytecode[0])),
 		license:      newPtr(unsafe.Pointer(&lic[0])),

--- a/prog_test.go
+++ b/prog_test.go
@@ -41,7 +41,7 @@ func TestProgramRun(t *testing.T) {
 
 	t.Log(ins)
 
-	prog, err := NewProgram(&ProgramSpec{"test", XDP, ins, "MIT", 0})
+	prog, err := NewProgram(&ProgramSpec{"test", XDP, AttachTypeNone, ins, "MIT", 0})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/prog_test.go
+++ b/prog_test.go
@@ -41,7 +41,7 @@ func TestProgramRun(t *testing.T) {
 
 	t.Log(ins)
 
-	prog, err := NewProgram(&ProgramSpec{"test", XDP, AttachTypeNone, ins, "MIT", 0})
+	prog, err := NewProgram(&ProgramSpec{"test", XDP, AttachNone, ins, "MIT", 0})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syscalls.go
+++ b/syscalls.go
@@ -94,7 +94,7 @@ type bpfProgLoadAttr struct {
 	progFlags          uint32     // since 4.11 e07b98d9bffe
 	progName           bpfObjName // since 4.15 067cae47771c
 	progIfIndex        uint32     // since 4.15 1f6f4cb7ba21
-	expectedAttachType uint32     // since 4.17 5e43f899b03a
+	expectedAttachType AttachType // since 4.17 5e43f899b03a
 }
 
 type bpfProgInfo struct {

--- a/types.go
+++ b/types.go
@@ -175,4 +175,60 @@ const (
 	LWTXmit
 	// SockOps program
 	SockOps
+	// SkSKB program
+	SkSKB
+	// CGroupDevice program
+	CGroupDevice
+	// SkMsg program
+	SkMsg
+	// RawTracepoint program
+	RawTracepoint
+	// CGroupSockAddr program
+	CGroupSockAddr
+	// LWTSeg6Local program
+	LWTSeg6Local
+	// LircMode2 program
+	LircMode2
+	// SkReuseport program
+	SkReuseport
+	// FlowDissector program
+	FlowDissector
+	// CGroupSysctl program
+	CGroupSysctl
+	// RawTracepointWritable program
+	RawTracepointWritable
+	// CGroupSockopt program
+	CGroupSockopt
+)
+
+// AttachType of the eBPF program
+type AttachType uint32
+
+// AttachTypeNone is an alias for AttachCGroupInetIngress for readability reasons
+const AttachTypeNone AttachType = 0
+
+const (
+	AttachCGroupInetIngress AttachType = iota
+	AttachCGroupInetEgress
+	AttachCGroupInetSockCreate
+	AttachCGroupSockOps
+	AttachSkSKBStreamParser
+	AttachSkSKBStreamVerdict
+	AttachCGroupDevice
+	AttachSkMsgVerdict
+	AttachCGroupInet4Bind
+	AttachCGroupInet6Bind
+	AttachCGroupInet4Connect
+	AttachCGroupInet6Connect
+	AttachCGroupInet4PostBind
+	AttachCGroupInet6PostBind
+	AttachCGroupUDP4Sendmsg
+	AttachCGroupUDP6Sendmsg
+	AttachLircMode2
+	AttachFlowDissector
+	AttachCGroupSysctl
+	AttachCGroupUDP4Recvmsg
+	AttachCGroupUDP6Recvmsg
+	AttachCGroupGetsockopt
+	AttachCGroupSetsockopt
 )

--- a/types.go
+++ b/types.go
@@ -201,11 +201,13 @@ const (
 	CGroupSockopt
 )
 
-// AttachType of the eBPF program
+// AttachType of the eBPF program, needed to differentiate allowed context accesses in
+// some newer program types like CGroupSockAddr. Should be set to AttachNone if not required.
+// Will cause invalid argument (EINVAL) at program load time if set incorrectly.
 type AttachType uint32
 
-// AttachTypeNone is an alias for AttachCGroupInetIngress for readability reasons
-const AttachTypeNone AttachType = 0
+// AttachNone is an alias for AttachCGroupInetIngress for readability reasons
+const AttachNone AttachType = 0
 
 const (
 	AttachCGroupInetIngress AttachType = iota


### PR DESCRIPTION
This adds support for expectedAttachType (necessary for many of the new program types) and a bunch of new ProgTypes.

I'm not sure what this library's compatibility targets are, this has only been tested on Linux 4.19 and upwards, so if a lower target is desired this needs testing there.