### PR TITLE
map, program: return error when using closed fds

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ blocks:
       jobs:
       - name: Test on 5.0.13
         commands:
-          - timeout -s KILL 30s ./run-tests.sh 5.0.13
+          - timeout -s KILL 60s ./run-tests.sh 5.0.13
       - name: Test on 4.19.40
         commands:
-          - timeout -s KILL 30s ./run-tests.sh 4.19.40
+          - timeout -s KILL 60s ./run-tests.sh 4.19.40

--- a/abi.go
+++ b/abi.go
@@ -80,7 +80,7 @@ func newMapABIFromSpec(spec *MapSpec) *MapABI {
 	}
 }
 
-func newMapABIFromFd(fd uint32) (*MapABI, error) {
+func newMapABIFromFd(fd *bpfFD) (*MapABI, error) {
 	info, err := bpfGetMapInfoByFD(fd)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func newProgramABIFromSpec(spec *ProgramSpec) *ProgramABI {
 	}
 }
 
-func newProgramABIFromFd(fd uint32) (*ProgramABI, error) {
+func newProgramABIFromFd(fd *bpfFD) (*ProgramABI, error) {
 	info, err := bpfGetProgInfoByFD(fd)
 	if err != nil {
 		return nil, err

--- a/editor.go
+++ b/editor.go
@@ -36,6 +36,11 @@ func (ed *Editor) rewriteMap(symbol string, m *Map, overwrite bool) error {
 		return &unreferencedSymbolError{symbol}
 	}
 
+	fd, err := m.fd.value()
+	if err != nil {
+		return err
+	}
+
 	loadOp := asm.LoadImmOp(asm.DWord)
 
 	for _, index := range indices {
@@ -49,7 +54,7 @@ func (ed *Editor) rewriteMap(symbol string, m *Map, overwrite bool) error {
 		}
 
 		load.Src = 1
-		load.Constant = int64(m.fd)
+		load.Constant = int64(fd)
 	}
 
 	return nil

--- a/map_test.go
+++ b/map_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -63,6 +64,22 @@ func TestMap(t *testing.T) {
 	}
 	if k != 1 {
 		t.Error("Want key 1, got", k)
+	}
+}
+
+func TestMapClose(t *testing.T) {
+	m := createArray(t)
+
+	if err := m.Close(); err != nil {
+		t.Fatal("Can't close map:", err)
+	}
+
+	if err := m.Put(uint32(0), uint32(42)); errors.Cause(err) != errClosedFd {
+		t.Fatal("Put doesn't check for closed fd", err)
+	}
+
+	if _, err := m.GetBytes(uint32(0)); errors.Cause(err) != errClosedFd {
+		t.Fatal("Get doesn't check for closed fd", err)
 	}
 }
 

--- a/prog_test.go
+++ b/prog_test.go
@@ -70,6 +70,24 @@ func TestProgramRun(t *testing.T) {
 	}
 }
 
+func TestProgramClose(t *testing.T) {
+	prog, err := NewProgram(&ProgramSpec{
+		Type: SocketFilter,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+		License: "MIT",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prog.Close(); err != nil {
+		t.Fatal("Can't close program:", err)
+	}
+}
+
 func TestProgramPin(t *testing.T) {
 	prog, err := NewProgram(&ProgramSpec{
 		Type: SocketFilter,


### PR DESCRIPTION
We had a bug that went unnoticed for a while because a program was closed
before being put into a program array. The Put() normally returns EBADF
due to the file descriptor being invalid. However, when investigating our
bug we saw ocurrences where it failed with EINVAL. This is likely because
the file descriptor had been re-used in the time between Close() and Put().
If the re-used file descriptor had been pointing at a BPF program by accident,
we would have silently corrupted the program array, possibly creating
infinite loops, etc.

To make this less likely, track whether a file descriptor has been closed or
not. Using a closed fd now returns an error. Calling FD() on a closed map
or program will now panic the program.