### PR TITLE
perf: use x/sys/unix where possible

### DIFF
--- a/perf_test.go
+++ b/perf_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestPerfReader(t *testing.T) {
@@ -303,10 +305,10 @@ func makeRing(size, offset int) *ringReader {
 		ring[i] = byte(i)
 	}
 
-	meta := perfEventMeta{
-		dataHead: uint64(len(ring) + offset),
-		dataTail: uint64(offset),
-		dataSize: uint64(len(ring)),
+	meta := unix.PerfEventMmapPage{
+		Data_head: uint64(len(ring) + offset),
+		Data_tail: uint64(offset),
+		Data_size: uint64(len(ring)),
 	}
 
 	return newRingReader(&meta, ring)

--- a/syscalls.go
+++ b/syscalls.go
@@ -162,35 +162,6 @@ type bpfProgInfo struct {
 	name         bpfObjName
 }
 
-type perfEventAttr struct {
-	perfType     uint32
-	size         uint32
-	config       uint64
-	samplePeriod uint64
-	sampleType   uint64
-	readFormat   uint64
-
-	// see include/uapi/linux/
-	// for details
-	flags uint64
-
-	wakeupEventsOrWatermark uint32
-	bpType                  uint32
-	bpAddr                  uint64
-	bpLen                   uint64
-
-	sampleRegsUser  uint64
-	sampleStackUser uint32
-	clockID         int32
-
-	sampleRegsIntr uint64
-
-	auxWatermark   uint32
-	sampleMaxStack uint16
-
-	padding uint16
-}
-
 type bpfProgTestRunAttr struct {
 	fd          uint32
 	retval      uint32
@@ -416,19 +387,6 @@ func bpfGetProgramFDByID(id uint32) (*bpfFD, error) {
 	return newBPFFD(uint32(ptr)), nil
 }
 
-type wrappedErrno struct {
-	errNo   unix.Errno
-	message string
-}
-
-func (werr *wrappedErrno) Error() string {
-	return werr.message
-}
-
-func (werr *wrappedErrno) Cause() error {
-	return werr.errNo
-}
-
 func bpfCall(cmd int, attr unsafe.Pointer, size uintptr) (uintptr, error) {
 	r1, _, errNo := unix.Syscall(unix.SYS_BPF, uintptr(cmd), uintptr(attr), size)
 	runtime.KeepAlive(attr)
@@ -439,90 +397,6 @@ func bpfCall(cmd int, attr unsafe.Pointer, size uintptr) (uintptr, error) {
 	}
 
 	return r1, err
-}
-
-func perfEventOpen(attr *perfEventAttr, pid, cpu, groupFd int, flags uint) (int, error) {
-	const flagCloexec = 1 << 3
-
-	// Always overwrite size
-	attr.size = uint32(unsafe.Sizeof(*attr))
-
-	// Force CLOEXEC
-	flags |= flagCloexec
-
-	efd, _, errNo := unix.Syscall6(unix.SYS_PERF_EVENT_OPEN, uintptr(unsafe.Pointer(attr)),
-		uintptr(pid), uintptr(cpu), uintptr(groupFd), uintptr(flags), 0)
-
-	var err error
-	switch errNo {
-	case 0:
-		err = nil
-	case unix.E2BIG:
-		err = &wrappedErrno{unix.E2BIG, "perf_event_attr size is incorrect, check size field for what the correct size should be"}
-	case unix.EACCES:
-		err = &wrappedErrno{unix.EACCES, "insufficient capabilities to create this event"}
-	case unix.EBADFD:
-		err = &wrappedErrno{unix.EBADFD, "group_fd is invalid"}
-	case unix.EBUSY:
-		err = &wrappedErrno{unix.EBUSY, "another event already has exclusive access to the PMU"}
-	case unix.EFAULT:
-		err = &wrappedErrno{unix.EFAULT, "attr points to an invalid address"}
-	case unix.EINVAL:
-		err = &wrappedErrno{unix.EINVAL, "the specified event is invalid, most likely because a configuration parameter is invalid (i.e. too high, too low, etc)"}
-	case unix.EMFILE:
-		err = &wrappedErrno{unix.EMFILE, "this process has reached its limits for number of open events that it may have"}
-	case unix.ENODEV:
-		err = &wrappedErrno{unix.ENODEV, "this processor architecture does not support this event type"}
-	case unix.ENOENT:
-		err = &wrappedErrno{unix.ENOENT, "the type setting is not valid"}
-	case unix.ENOSPC:
-		err = &wrappedErrno{unix.ENOSPC, "the hardware limit for breakpoints capacity has been reached"}
-	case unix.ENOSYS:
-		err = &wrappedErrno{unix.ENOSYS, "sample type not supported by the hardware"}
-	case unix.EOPNOTSUPP:
-		err = &wrappedErrno{unix.EOPNOTSUPP, "this event is not supported by the hardware or requires a feature not supported by the hardware"}
-	case unix.EOVERFLOW:
-		err = &wrappedErrno{unix.EOVERFLOW, "sample_max_stack is larger than the kernel support; check \"/proc/sys/kernel/perf_event_max_stack\" for maximum supported size"}
-	case unix.EPERM:
-		err = &wrappedErrno{unix.EPERM, "insufficient capability to request exclusive access"}
-	case unix.ESRCH:
-		err = &wrappedErrno{unix.ESRCH, "pid does not exist"}
-	default:
-		err = errNo
-	}
-
-	return int(efd), err
-}
-
-func newEventFd() (int, error) {
-	flags := unix.O_CLOEXEC | unix.O_NONBLOCK
-	ret, _, errno := unix.Syscall(unix.SYS_EVENTFD2, uintptr(0), uintptr(flags), 0)
-	if errno == 0 {
-		return int(ret), nil
-	}
-	return -1, errors.Wrapf(errno, "can't create event fd")
-}
-
-func newEpollFd(fds ...int) (int, error) {
-	epollfd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
-	if err != nil {
-		return -1, errors.Wrap(err, "can't create epoll fd")
-	}
-
-	for _, fd := range fds {
-		event := unix.EpollEvent{
-			Events: unix.EPOLLIN,
-			Fd:     int32(fd),
-		}
-
-		err := unix.EpollCtl(epollfd, unix.EPOLL_CTL_ADD, fd, &event)
-		if err != nil {
-			unix.Close(epollfd)
-			return -1, errors.Wrap(err, "can't add fd to epoll")
-		}
-	}
-
-	return epollfd, nil
 }
 
 func convertCString(in []byte) string {


### PR DESCRIPTION
Swap our home grown perf event and event fd implementations for the ones
from x/sys/unix.