### PR TITLE
allow ValueSize=4 for map-in-map

### DIFF
--- a/map.go
+++ b/map.go
@@ -80,8 +80,8 @@ func createMap(spec *MapSpec, inner *bpfFD) (*Map, error) {
 	case ArrayOfMaps:
 		fallthrough
 	case HashOfMaps:
-		if spec.ValueSize != 0 {
-			return nil, errors.Errorf("ValueSize must be zero for map of map")
+		if spec.ValueSize != 0 && spec.ValueSize != 4 {
+			return nil, errors.Errorf("ValueSize must be zero or four for map of map")
 		}
 		cpy.ValueSize = 4
 

--- a/map_test.go
+++ b/map_test.go
@@ -247,6 +247,35 @@ func createMapInMap(t *testing.T, typ MapType) *Map {
 	return m
 }
 
+func TestMapInMapValueSize(t *testing.T) {
+	spec := &MapSpec{
+		Type:       ArrayOfMaps,
+		KeySize:    4,
+		ValueSize:  0,
+		MaxEntries: 2,
+		InnerMap: &MapSpec{
+			Type:       Array,
+			KeySize:    4,
+			ValueSize:  4,
+			MaxEntries: 2,
+		},
+	}
+
+	if _, err := NewMap(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	spec.ValueSize = 4
+	if _, err := NewMap(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	spec.ValueSize = 1
+	if _, err := NewMap(spec); err == nil {
+		t.Fatal("Expected an error")
+	}
+}
+
 func TestIterateEmptyMap(t *testing.T) {
 	hash := createHash()
 	defer hash.Close()


### PR DESCRIPTION
This allows the same program to be loaded with both libbpf and
newtools/ebpf. The kernel expects value_size=4 and libbpf does not modify
the value_size from bpf_map_def.